### PR TITLE
Add initial implementation for macOS target functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ readme = "README.md"
 
 [dependencies]
 nix = "0.17.0"
+libproc = "0.7.2"
+libc = "0.2.72"
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+mach = "0.3"
+security-framework-sys = "1.0"

--- a/Documentation/MacOS.md
+++ b/Documentation/MacOS.md
@@ -1,0 +1,17 @@
+# Running Headcrab on macOS
+
+macOS has additional security measures and doesn't allow to manipulate other processes unless you have permissions
+to do so.
+
+Add linker options to `.cargo/config`:
+
+    [build]
+    rustflags = ["-C", "link-args=-sectcreate __TEXT __info_plist Info.plist"]
+
+You can check if the section has been added to the binary by running
+
+    $ codesign -dvvv <path to binary> 2>&1 | grep Info.plist
+
+## Address space layout randomization
+
+ASLR can be disabled with an undocumented attribute for `posix_spawn`: `_POSIX_SPAWN_DISABLE_ASLR` (0x0100)

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple
+.com/DTDs/PropertyList-1.0.dtd">
+
+<!-- This file sets the required privileges to use task_for_pid function. -->
+
+<plist version="1.0">
+	<dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>English</string>
+
+        <key>CFBundleIdentifier</key>
+        <string>com.apple.taskforpid</string>
+
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+
+        <key>CFBundleName</key>
+        <string>taskforpid</string>
+
+        <key>CFBundleVersion</key>
+        <string>1.0</string>
+
+        <key>SecTaskAccess</key>
+        <array>
+			<string>allowed</string>
+			<string>debug</string>
+        </array>
+	</dict>
+</plist>

--- a/src/target/macos/mod.rs
+++ b/src/target/macos/mod.rs
@@ -1,0 +1,214 @@
+mod vmmap;
+
+use libc::pid_t;
+use mach::{kern_return, message, port, traps, vm, vm_types::*};
+use nix::{
+    sys::signal::{self, Signal},
+    unistd::Pid,
+};
+use security_framework_sys::authorization::*;
+use std::{
+    ffi::CString,
+    io,
+    mem::{self, MaybeUninit},
+    ptr,
+};
+
+// Undocumented flag to disable address space layout randomization.
+const _POSIX_SPAWN_DISABLE_ASLR: i32 = 0x0100;
+
+pub struct Target {
+    /// Port for a target task
+    port: port::mach_port_name_t,
+    pid: Pid,
+}
+
+impl Target {
+    /// Launch a new process.
+    /// Returns an opaque target handle.
+    pub fn launch(path: &str) -> Result<Target, Box<dyn std::error::Error>> {
+        request_authorization()?;
+
+        let path = CString::new(path)?;
+
+        let child = unsafe {
+            let mut pid: pid_t = 0;
+
+            let mut attr = MaybeUninit::<libc::posix_spawnattr_t>::uninit();
+            let res = libc::posix_spawnattr_init(attr.as_mut_ptr());
+            if res != 0 {
+                // TODO: properly wrap error types
+                return Err(Box::new(io::Error::last_os_error()));
+            }
+
+            let mut attr = attr.assume_init();
+
+            let res = libc::posix_spawnattr_setflags(
+                &mut attr,
+                (libc::POSIX_SPAWN_START_SUSPENDED | _POSIX_SPAWN_DISABLE_ASLR) as i16,
+            );
+            if res != 0 {
+                // TODO: properly wrap error types
+                return Err(Box::new(io::Error::last_os_error()));
+            }
+
+            let res = libc::posix_spawn(
+                &mut pid,
+                path.as_ptr(),
+                ptr::null(),
+                &attr,
+                ptr::null(),
+                ptr::null(),
+            );
+            if res != 0 {
+                // TODO: properly wrap error types
+                return Err(Box::new(io::Error::last_os_error()));
+            }
+
+            pid
+        };
+
+        let target_port = unsafe {
+            let self_port = traps::mach_task_self();
+            let mut target_port = 0;
+
+            let res = traps::task_for_pid(self_port, child, &mut target_port);
+
+            if res != kern_return::KERN_SUCCESS {
+                // TODO: properly wrap return errors
+                return Err(Box::new(io::Error::new(
+                            io::ErrorKind::Other,
+                            "Could not obtain task port for a process. This might be caused by insufficient permissions.",
+                        )));
+            }
+
+            target_port
+        };
+
+        Ok(Target {
+            port: target_port,
+            pid: Pid::from_raw(child),
+        })
+    }
+
+    /// Continues execution of a child process.
+    pub fn unpause(&self) -> Result<(), Box<dyn std::error::Error>> {
+        signal::kill(self.pid, Signal::SIGCONT)?;
+        Ok(())
+    }
+
+    /// Implements process memory read function.
+    /// This function uses vm_read function from the Mach API.
+    fn vm_read(
+        &self,
+        base: usize,
+        len: usize,
+        data: &mut [u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unsafe {
+            let mut data_count: message::mach_msg_type_number_t = 0;
+
+            let res = vm::mach_vm_read(
+                self.port,
+                base as mach_vm_address_t,
+                len as mach_vm_size_t,
+                data.as_mut_ptr() as *mut _,
+                &mut data_count,
+            );
+
+            if res != kern_return::KERN_SUCCESS {
+                // TODO: properly wrap error types
+                return Err(Box::new(io::Error::last_os_error()));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn get_addr_range(&self) -> Result<usize, Box<dyn std::error::Error>> {
+        let regs = vmmap::macosx_debug_regions(self.pid, self.port);
+        for r in regs {
+            println!(
+                "{:x} -> {:x}, exec: {}, read: {}, write: {} [{:?}]",
+                r.address,
+                r.end(),
+                r.is_exec(),
+                r.is_read(),
+                r.is_write(),
+                r
+            );
+        }
+        Ok(0)
+    }
+
+    pub fn read_string(
+        &self,
+        base: usize,
+        len: usize,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let mut read_buf = vec![0; len];
+        self.vm_read(base, len, &mut read_buf)?;
+        Ok(String::from_utf8(read_buf)?)
+    }
+
+    pub fn read_usize(&self, base: usize) -> Result<usize, Box<dyn std::error::Error>> {
+        let mut read_buf = [0; mem::size_of::<usize>()];
+        self.vm_read(base, mem::size_of::<usize>(), &mut read_buf)?;
+        Ok(usize::from_ne_bytes(read_buf))
+    }
+}
+
+fn request_authorization() -> Result<(), Box<dyn std::error::Error>> {
+    // TODO: rewrite this ugly ugly code when AuthorizationCopyRights is available is security_framework
+
+    let name = CString::new("system.privilege.taskport:")?;
+
+    let auth_items = [AuthorizationItem {
+        name: name.as_ptr(),
+        valueLength: 0,
+        value: ptr::null_mut(),
+        flags: 0,
+    }];
+
+    let auth_item_set = AuthorizationRights {
+        count: 1,
+        items: auth_items.as_ptr() as *mut _,
+    };
+
+    let auth_flags = kAuthorizationFlagExtendRights
+        | kAuthorizationFlagPreAuthorize
+        | kAuthorizationFlagInteractionAllowed
+        | (1 << 5);
+
+    let mut auth_ref = MaybeUninit::<AuthorizationRef>::uninit();
+    let res =
+        unsafe { AuthorizationCreate(ptr::null(), ptr::null(), auth_flags, auth_ref.as_mut_ptr()) };
+
+    if res != errAuthorizationSuccess {
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::Other,
+            "AuthorizationCreate",
+        )));
+    }
+
+    let auth_ref = unsafe { auth_ref.assume_init() };
+
+    let mut target_rights = MaybeUninit::<AuthorizationRights>::uninit();
+    let res = unsafe {
+        AuthorizationCopyRights(
+            auth_ref,
+            &auth_item_set,
+            ptr::null(),
+            auth_flags,
+            target_rights.as_mut_ptr() as *mut *mut _,
+        )
+    };
+
+    if res != errAuthorizationSuccess {
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::Other,
+            "AuthorizationCopyRights",
+        )));
+    }
+
+    Ok(())
+}

--- a/src/target/macos/vmmap.rs
+++ b/src/target/macos/vmmap.rs
@@ -1,0 +1,119 @@
+// Copyright (C) Julia Evans
+//
+// Implementation of vmmap was taken from
+// https://jvns.ca/blog/2018/01/26/mac-memory-maps/
+
+use libproc::libproc::proc_pid::regionfilename;
+use mach::{
+    kern_return::KERN_SUCCESS,
+    mach_types::*,
+    message::*,
+    port::{mach_port_name_t, mach_port_t},
+    task::*,
+    task_info::*,
+    vm_region::{
+        vm_region_basic_info_data_64_t, vm_region_basic_info_data_t, vm_region_info_t,
+        VM_REGION_BASIC_INFO,
+    },
+    vm_types::*,
+};
+use nix::unistd::Pid;
+use std::mem;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Region {
+    pub size: mach_vm_size_t,
+    pub info: vm_region_basic_info_data_t,
+    pub address: mach_vm_address_t,
+    pub count: mach_msg_type_number_t,
+    pub filename: Option<String>,
+}
+
+impl Region {
+    pub fn end(&self) -> mach_vm_address_t {
+        self.address + self.size as mach_vm_address_t
+    }
+
+    pub fn is_read(&self) -> bool {
+        self.info.protection & mach::vm_prot::VM_PROT_READ != 0
+    }
+    pub fn is_write(&self) -> bool {
+        self.info.protection & mach::vm_prot::VM_PROT_WRITE != 0
+    }
+    pub fn is_exec(&self) -> bool {
+        self.info.protection & mach::vm_prot::VM_PROT_EXECUTE != 0
+    }
+}
+
+pub(crate) fn macosx_debug_regions(pid: Pid, task: mach_port_name_t) -> Vec<Region> {
+    let init_region = mach_vm_region(pid, task, 1).unwrap();
+    let mut vec = vec![];
+    let mut region = init_region.clone();
+    vec.push(init_region);
+    loop {
+        match mach_vm_region(pid, task, region.end()) {
+            Some(r) => {
+                vec.push(r.clone());
+                region = r;
+            }
+            _ => return vec,
+        }
+    }
+}
+
+pub(crate) fn get_task_info(task: mach_port_name_t) -> Option<task_dyld_info> {
+    const TASK_DYLD_INFO_COUNT: usize =
+        mem::size_of::<task_dyld_info>() / mem::size_of::<natural_t>();
+    let mut count = TASK_DYLD_INFO_COUNT;
+    let mut dyld_info = unsafe { mem::zeroed::<task_dyld_info>() };
+    let ret = unsafe {
+        task_info(
+            task,
+            TASK_DYLD_INFO,
+            &mut dyld_info as *mut task_dyld_info as task_info_t,
+            &mut count as *mut usize as *mut mach_msg_type_number_t,
+        )
+    };
+
+    if ret != KERN_SUCCESS {
+        None
+    } else {
+        Some(dyld_info)
+    }
+}
+
+pub(crate) fn mach_vm_region(
+    pid: Pid,
+    target_task: mach_port_name_t,
+    mut address: mach_vm_address_t,
+) -> Option<Region> {
+    let mut count = mem::size_of::<vm_region_basic_info_data_64_t>() as mach_msg_type_number_t;
+    let mut object_name: mach_port_t = 0;
+    let mut size = unsafe { mem::zeroed::<mach_vm_size_t>() };
+    let mut info = unsafe { mem::zeroed::<vm_region_basic_info_data_t>() };
+    let result = unsafe {
+        mach::vm::mach_vm_region(
+            target_task as vm_task_entry_t,
+            &mut address,
+            &mut size,
+            VM_REGION_BASIC_INFO,
+            &mut info as *mut vm_region_basic_info_data_t as vm_region_info_t,
+            &mut count,
+            &mut object_name,
+        )
+    };
+    if result != KERN_SUCCESS {
+        return None;
+    }
+    let filename = match regionfilename(pid.as_raw(), address) {
+        Ok(x) => Some(x),
+        _ => None,
+    };
+    Some(Region {
+        size,
+        info,
+        address,
+        count,
+        filename,
+    })
+}

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -2,3 +2,8 @@
 mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::*;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::*;


### PR DESCRIPTION
- Partially address #1
- Implement Target::launch to launch a process in a debug mode (suspended & with ASLR disabled)
- Implement Target::vm_read, a simple wrapper around mach_vm_read