### PR TITLE
Add a naive implementation for DWARF symbols reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,14 @@ readme = "README.md"
 nix = "0.17.0"
 libproc = "0.7.2"
 libc = "0.2.72"
+object = "0.20"
 
+# Dependencies specific to macOS & Linux
+[target.'cfg(unix)'.dependencies]
+gimli = "0.22.0"
+memmap = "0.7.0"
+
+# Dependencies specific to macOS
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach = "0.3"
 security-framework-sys = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,6 @@
 
 /// Functions to work with target processes: reading & writing memory, process control functions, etc.
 pub mod target;
+
+/// Symbolication layer.
+pub mod symbol;

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -1,0 +1,97 @@
+// This module provides a naive implementation of symbolication for the time being.
+// It should be expanded to support multiple data sources.
+
+use gimli::{self, read::EvaluationResult};
+use memmap;
+use object::read::{Object, ObjectSection};
+use std::{borrow::Cow, collections::BTreeMap, fs::File};
+
+pub struct Dwarf {
+    vars: BTreeMap<String, usize>,
+}
+
+impl Dwarf {
+    // todo: impl loader struct instead of taking 'path' as an argument.
+    // It will be required to e.g. load coredumps, or external debug info, or to
+    // communicate with rustc/lang servers.
+    pub fn new(path: &str) -> Result<Dwarf, Box<dyn std::error::Error>> {
+        // This is completely inefficient and hacky code, but currently it serves the only
+        // purpose of getting addresses of static variables.
+        // TODO: this will be reworked in a more complete symbolication framework.
+        let mut vars = BTreeMap::new();
+
+        // Load ELF/Mach-O object file
+        let file = File::open(path)?;
+        let mmap = unsafe { memmap::Mmap::map(&file)? };
+
+        let object = object::File::parse(&*mmap)?;
+        let endian = if object.is_little_endian() {
+            gimli::RunTimeEndian::Little
+        } else {
+            gimli::RunTimeEndian::Big
+        };
+
+        // This can be also processed in parallel.
+        let loader = |id: gimli::SectionId| -> Result<Cow<[u8]>, gimli::Error> {
+            match object.section_by_name(id.name()) {
+                Some(ref section) => Ok(section
+                    .uncompressed_data()
+                    .unwrap_or(Cow::Borrowed(&[][..]))),
+                None => Ok(Cow::Borrowed(&[][..])),
+            }
+        };
+        let sup_loader = |_| Ok(Cow::Borrowed(&[][..])); // we don't need a supplementary object file for now
+
+        let dwarf_cow = gimli::Dwarf::load(loader, sup_loader)?;
+
+        let borrow_section: &dyn for<'a> Fn(
+            &'a Cow<[u8]>,
+        )
+            -> gimli::EndianSlice<'a, gimli::RunTimeEndian> =
+            &|section| gimli::EndianSlice::new(&*section, endian);
+
+        let dwarf = dwarf_cow.borrow(&borrow_section);
+
+        // Create `EndianSlice`s for all of the sections.
+        let mut units = dwarf.units();
+
+        while let Some(header) = units.next()? {
+            let unit = dwarf.unit(header)?;
+            let mut entries = unit.entries();
+            while let Some((_, entry)) = entries.next_dfs()? {
+                // If we find an entry for a function, print it.
+                if entry.tag() == gimli::DW_TAG_variable {
+                    let name = if let Some(attr) = entry.attr(gimli::DW_AT_name)? {
+                        dwarf.attr_string(&unit, attr.value())?.to_string()?
+                    } else {
+                        continue;
+                    };
+
+                    let expr = if let Some(attr) = entry.attr(gimli::DW_AT_location)? {
+                        attr.exprloc_value()
+                    } else {
+                        continue;
+                    };
+
+                    // TODO: evaluation should not happen here
+                    if let Some(expr) = expr {
+                        let mut eval = expr.evaluation(unit.encoding());
+                        match eval.evaluate()? {
+                            EvaluationResult::RequiresRelocatedAddress(reloc_addr) => {
+                                vars.insert(name.to_owned(), reloc_addr as usize);
+                            }
+                            _ev_res => {} // do nothing for now
+                        }
+                    }
+                }
+            }
+        }
+
+        // DW_TAG_variable
+        Ok(Dwarf { vars })
+    }
+
+    pub fn get_var_address(&self, name: &str) -> Option<usize> {
+        self.vars.get(name).cloned()
+    }
+}

--- a/tests/readmem.rs
+++ b/tests/readmem.rs
@@ -1,19 +1,31 @@
 //! This is a simple test to read memory from a child process.
 
-use headcrab::target::Target;
+use headcrab::{symbol::Dwarf, target::Target};
 
 static BIN_PATH: &str = "./tests/hello";
-const STR_ADDR: usize = 0x404028;
+
+// FIXME: this should be an internal impl detail
+#[cfg(target_os = "macos")]
+static MAC_DSYM_PATH: &str = "./tests/hello.dSYM/Contents/Resources/DWARF/hello";
 
 #[test]
 fn read_memory() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "macos")]
+    let debuginfo = Dwarf::new(MAC_DSYM_PATH)?;
+    #[cfg(not(target_os = "macos"))]
+    let debuginfo = Dwarf::new(BIN_PATH)?;
+
+    let str_addr = debuginfo
+        .get_var_address("STATICVAR")
+        .expect("Expected static var has not been found in the target binary");
+
     let target = Target::launch(BIN_PATH)?;
 
     // Read pointer
-    let str_addr = target.read_usize(STR_ADDR)?;
+    let ptr_addr = target.read_usize(str_addr)?;
 
     // Read current value
-    let rval = target.read_string(str_addr, 13)?;
+    let rval = target.read_string(ptr_addr, 13)?;
     assert_eq!(rval, "Hello, world!");
 
     target.unpause()?;


### PR DESCRIPTION
This works on Mac & Linux. Now we don't have to hardcode variable addresses, yay!