### PR TITLE
Don't produce a dynamically linked PIE executable test 

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ BINS = $(patsubst %.c,%,$(SRCS))
 all: $(BINS)
 
 %: %.c
-	$(CC) -g -o $@ $^
+	$(CC) -g -no-pie -o $@ $^
 
 clean:
 	rm -f $(BINS)


### PR DESCRIPTION
Some distributions (like arch) have the flag
```--enable-default-pie``` turned on by default [1].

By having ```-no-pie``` we can be assured that the test executable
addresses will be valid without having to calculate the absolute
ones.

[1] - https://nanxiao.me/en/gccs-enable-enable-default-pie-option-make-you-stuck-at-relocation-r_x86_64_32s-against-error/