### PR TITLE
Improve OSX build instructions

### DIFF
--- a/Documentation/MacOS.md
+++ b/Documentation/MacOS.md
@@ -6,7 +6,7 @@ to do so.
 Add linker options to `.cargo/config`:
 
     [build]
-    rustflags = ["-C", "link-args=-sectcreate __TEXT __info_plist Info.plist"]
+    rustflags = ["-C", "link-args=-sectcreate __TEXT __info_plist </path/to/>Info.plist"]
 
 You can check if the section has been added to the binary by running
 


### PR DESCRIPTION
The previous instructions did not work in my OSX. 
I had to fill in a full path to the Info.plist file for it to work. 
Not sure if this is the best option, but hey... it works.