### PR TITLE
Split out code common for all *nix platform

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,37 @@
 task:
+  name: stable x86_64-unknown-freebsd-10
+  freebsd_instance:
+    image: freebsd-10-4-release-amd64
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable 
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo fmt --all -- --check
+    - make -C tests/testees
+    - cargo clippy
+    - cargo test 
+
+task:
+  name: stable x86_64-unknown-freebsd-11
+  freebsd_instance:
+    image: freebsd-11-3-stable-amd64-v20200213
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable 
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo fmt --all -- --check
+    - make -C tests/testees
+    - cargo clippy
+    - cargo test 
+task:
   name: stable x86_64-unknown-freebsd-12
   freebsd_instance:
     image: freebsd-12-1-release-amd64
@@ -10,6 +43,23 @@ task:
     - rustup default stable 
   test_script:
     - . $HOME/.cargo/env
-    - cargo build
-    - make -C tests
+    - cargo fmt --all -- --check
+    - make -C tests/testees
+    - cargo clippy
+    - cargo test 
+task:
+  name: stable x86_64-unknown-freebsd-12
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable 
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo fmt --all -- --check
+    - make -C tests/testees
+    - cargo clippy
     - cargo test 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,5 +10,6 @@ task:
     - rustup default stable 
   test_script:
     - . $HOME/.cargo/env
+    - cargo build
     - make -C tests
     - cargo test 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,8 @@ task:
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
     - . $HOME/.cargo/env
     - rustup default stable 
+    - rustup component add clippy
+    - rustup component add rustfmt
   test_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
@@ -25,6 +27,8 @@ task:
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
     - . $HOME/.cargo/env
     - rustup default stable 
+    - rustup component add clippy
+    - rustup component add rustfmt
   test_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check
@@ -42,6 +46,8 @@ task:
     - sh rustup.sh --default-toolchain stable -y --profile=minimal
     - . $HOME/.cargo/env
     - rustup default stable 
+    - rustup component add clippy
+    - rustup component add rustfmt
   test_script:
     - . $HOME/.cargo/env
     - cargo fmt --all -- --check

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,22 +31,7 @@ task:
     - make -C tests/testees
     - cargo clippy
     - cargo test 
-task:
-  name: stable x86_64-unknown-freebsd-12
-  freebsd_instance:
-    image: freebsd-12-1-release-amd64
-  setup_script:
-    - pkg install -y curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh --default-toolchain stable -y --profile=minimal
-    - . $HOME/.cargo/env
-    - rustup default stable 
-  test_script:
-    - . $HOME/.cargo/env
-    - cargo fmt --all -- --check
-    - make -C tests/testees
-    - cargo clippy
-    - cargo test 
+
 task:
   name: stable x86_64-unknown-freebsd-12
   freebsd_instance:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,14 @@
+task:
+  name: stable x86_64-unknown-freebsd-12
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh --default-toolchain stable -y --profile=minimal
+    - . $HOME/.cargo/env
+    - rustup default stable 
+  test_script:
+    - . $HOME/.cargo/env
+    - make -C tests
+    - cargo test 

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -5,7 +5,8 @@ use std::{
     mem,
 };
 
-use crate::target::unix::UnixTarget;
+use crate::target::unix::{self, UnixTarget};
+
 /// This structure holds the state of a debuggee on Linux based systems
 /// You can use it to read & write debuggee's memory, pause it, set breakpoints, etc.
 pub struct LinuxTarget {
@@ -22,7 +23,7 @@ impl UnixTarget for LinuxTarget {
 impl LinuxTarget {
     /// Launches a new debuggee process
     pub fn launch(path: &str) -> Result<LinuxTarget, Box<dyn std::error::Error>> {
-        let pid = crate::target::unix::launch(path)?;
+        let pid = unix::launch(path)?;
         Ok(LinuxTarget { pid })
     }
 

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -26,7 +26,7 @@ impl LinuxTarget {
         Ok(LinuxTarget { pid })
     }
 
-    /// Uses this process as a debuggee. 
+    /// Uses this process as a debuggee.
     pub fn me() -> LinuxTarget {
         LinuxTarget { pid: getpid() }
     }

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -5,53 +5,35 @@ use std::{
     mem,
 };
 
-use crate::target::unix::Target;
-
-/// This structure holds the state of a debuggee.
+use crate::target::unix::UnixTarget;
+/// This structure holds the state of a debuggee on Linux based systems
 /// You can use it to read & write debuggee's memory, pause it, set breakpoints, etc.
+pub struct LinuxTarget {
+    pid: Pid,
+}
 
-impl Target {
-    /// Uses this process as a debuggee.
-    pub fn me() -> Target {
-        Target { pid: getpid() }
+impl UnixTarget for LinuxTarget {
+    /// Provides the Pid of the debugee process
+    fn pid(&self) -> Pid {
+        self.pid
+    }
+}
+
+impl LinuxTarget {
+    /// Launches a new debuggee process
+    pub fn launch(path: &str) -> Result<LinuxTarget, Box<dyn std::error::Error>> {
+        let pid = crate::target::unix::launch(path)?;
+        Ok(LinuxTarget { pid })
     }
 
-    // /// Launch a new debuggee process.
-    // /// Returns an opaque target handle which you can use to control the debuggee.
-    // pub fn launch(path: &str) -> Result<Target, Box<dyn std::error::Error>> {
-    //     // We start the debuggee by forking the parent process.
-    //     // The child process invokes `ptrace(2)` with the `PTRACE_TRACEME` parameter to enable debugging features for the parent.
-    //     // This requires a user to have a `SYS_CAP_PTRACE` permission. See `man capabilities(7)` for more information.
-    //     match fork()? {
-    //         ForkResult::Parent { child, .. } => {
-    //             let _status = waitpid(child, None);
-
-    //             // todo: handle this properly
-
-    //             Ok(Target { pid: child })
-    //         }
-    //         ForkResult::Child => {
-    //             ptrace::traceme()?;
-
-    //             let path = CString::new(path)?;
-    //             execv(&path, &[])?;
-
-    //             // execv replaces the process image, so this place in code will not be reached.
-    //             unreachable!();
-    //         }
-    //     }
-    // }
-
-    // /// Continues execution of a debuggee.
-    // pub fn unpause(&self) -> Result<(), Box<dyn std::error::Error>> {
-    //     // Read current value
-    //     ptrace::cont(self.pid, None)?;
-    //     Ok(())
-    // }
+    /// Uses this process as a debuggee. 
+    pub fn me() -> LinuxTarget {
+        LinuxTarget { pid: getpid() }
+    }
 
     /// Reads memory from a debuggee process.
     pub fn read(&self) -> ReadMemory {
-        ReadMemory::new(self.pid)
+        ReadMemory::new(self.pid())
     }
 }
 

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -1,12 +1,12 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::*;
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::*;
-
-#[cfg(target_os = "linux")]
-mod unix;
-#[cfg(target_os = "linux")]
-pub use unix::*;
 
 #[cfg(target_os = "macos")]
 mod macos;

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -3,6 +3,11 @@ mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::*;
 
+#[cfg(target_os = "linux")]
+mod unix;
+#[cfg(target_os = "linux")]
+pub use unix::*;
+
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -1,0 +1,42 @@
+use nix::{
+    sys::ptrace,
+    sys::wait::waitpid,
+    unistd::{execv, fork, ForkResult, Pid},
+};
+use std::ffi::CString;
+impl UnixTarget for Target {}
+pub struct Target {
+    pub pid: Pid,
+}
+
+pub trait UnixTarget {
+    /// Launches the debugee from the path provided
+    fn launch(path: &str) -> Result<Target, Box<dyn std::error::Error>> {
+        // We start the debuggee by forking the parent process.
+        // The child process invokes `ptrace(2)` with the `PTRACE_TRACEME` parameter to enable debugging features for the parent.
+        // This requires a user to have a `SYS_CAP_PTRACE` permission. See `man capabilities(7)` for more information.
+        match fork()? {
+            ForkResult::Parent { child, .. } => {
+                let _status = waitpid(child, None);
+
+                // todo: handle this properly
+                Ok(Target { pid: child })
+            }
+            ForkResult::Child => {
+                ptrace::traceme()?;
+
+                let path = CString::new(path)?;
+                execv(&path, &[])?;
+
+                // execv replaces the process image, so this place in code will not be reached.
+                unreachable!();
+            }
+        }
+    }
+
+    /// Continues execution of a debuggee.
+    fn unpause(&self, t: &Target) -> Result<(), Box<dyn std::error::Error>> {
+        ptrace::cont(t.pid, None)?;
+        Ok(())
+    }
+}

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -4,39 +4,38 @@ use nix::{
     unistd::{execv, fork, ForkResult, Pid},
 };
 use std::ffi::CString;
-impl UnixTarget for Target {}
-pub struct Target {
-    pub pid: Pid,
+/// This trait defines the common behavior for all *nix targets 
+pub trait UnixTarget {
+    /// Provides the Pid of the debugee process
+    fn pid(&self) -> Pid;
+
+    /// Continues execution of a debuggee. 
+    fn unpause(&self) -> Result<(), Box<dyn std::error::Error>> {
+        ptrace::cont(self.pid(), None)?;
+        Ok(())
+    }
 }
 
-pub trait UnixTarget {
-    /// Launches the debugee from the path provided
-    fn launch(path: &str) -> Result<Target, Box<dyn std::error::Error>> {
-        // We start the debuggee by forking the parent process.
-        // The child process invokes `ptrace(2)` with the `PTRACE_TRACEME` parameter to enable debugging features for the parent.
-        // This requires a user to have a `SYS_CAP_PTRACE` permission. See `man capabilities(7)` for more information.
-        match fork()? {
-            ForkResult::Parent { child, .. } => {
-                let _status = waitpid(child, None);
+/// Launch a new debuggee process.
+pub(crate) fn launch(path: &str) -> Result<Pid, Box<dyn std::error::Error>> {
+    // We start the debuggee by forking the parent process.
+    // The child process invokes `ptrace(2)` with the `PTRACE_TRACEME` parameter to enable debugging features for the parent.
+    // This requires a user to have a `SYS_CAP_PTRACE` permission. See `man capabilities(7)` for more information.
+    match fork()? {
+        ForkResult::Parent { child, .. } => {
+            let _status = waitpid(child, None);
 
-                // todo: handle this properly
-                Ok(Target { pid: child })
-            }
-            ForkResult::Child => {
-                ptrace::traceme()?;
-
-                let path = CString::new(path)?;
-                execv(&path, &[])?;
-
-                // execv replaces the process image, so this place in code will not be reached.
-                unreachable!();
-            }
+            // todo: handle this properly
+            Ok(child)
         }
-    }
+        ForkResult::Child => {
+            ptrace::traceme()?;
 
-    /// Continues execution of a debuggee.
-    fn unpause(&self, t: &Target) -> Result<(), Box<dyn std::error::Error>> {
-        ptrace::cont(t.pid, None)?;
-        Ok(())
+            let path = CString::new(path)?;
+            execv(&path, &[])?;
+
+            // execv replaces the process image, so this place in code will not be reached.
+            unreachable!();
+        }
     }
 }

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -4,12 +4,13 @@ use nix::{
     unistd::{execv, fork, ForkResult, Pid},
 };
 use std::ffi::CString;
-/// This trait defines the common behavior for all *nix targets 
+
+/// This trait defines the common behavior for all *nix targets
 pub trait UnixTarget {
     /// Provides the Pid of the debugee process
     fn pid(&self) -> Pid;
 
-    /// Continues execution of a debuggee. 
+    /// Continues execution of a debuggee.
     fn unpause(&self) -> Result<(), Box<dyn std::error::Error>> {
         ptrace::cont(self.pid(), None)?;
         Ok(())

--- a/tests/readmem.rs
+++ b/tests/readmem.rs
@@ -1,7 +1,7 @@
 //! This is a simple test to read memory from a child process.
 
 #[cfg(target_os = "linux")]
-use headcrab::{symbol::Dwarf, target::Target, target::UnixTarget};
+use headcrab::{symbol::Dwarf, target::LinuxTarget, target::UnixTarget};
 
 static BIN_PATH: &str = "./tests/testees/hello";
 
@@ -22,7 +22,7 @@ fn read_memory() -> Result<(), Box<dyn std::error::Error>> {
         .get_var_address("STATICVAR")
         .expect("Expected static var has not been found in the target binary");
 
-    let target = Target::launch(BIN_PATH)?;
+    let target = LinuxTarget::launch(BIN_PATH)?;
 
     // Read pointer
     let mut ptr_addr: usize = 0;
@@ -34,7 +34,7 @@ fn read_memory() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&rval, b"Hello, world!");
 
-    target.unpause(&target)?;
+    target.unpause()?;
 
     Ok(())
 }

--- a/tests/readmem.rs
+++ b/tests/readmem.rs
@@ -1,5 +1,6 @@
 //! This is a simple test to read memory from a child process.
 
+#[cfg(target_os = "linux")]
 use headcrab::{symbol::Dwarf, target::Target, target::UnixTarget};
 
 static BIN_PATH: &str = "./tests/testees/hello";

--- a/tests/readmem.rs
+++ b/tests/readmem.rs
@@ -1,6 +1,6 @@
 //! This is a simple test to read memory from a child process.
 
-use headcrab::{symbol::Dwarf, target::Target};
+use headcrab::{symbol::Dwarf, target::Target, target::UnixTarget};
 
 static BIN_PATH: &str = "./tests/testees/hello";
 
@@ -33,7 +33,7 @@ fn read_memory() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&rval, b"Hello, world!");
 
-    target.unpause()?;
+    target.unpause(&target)?;
 
     Ok(())
 }


### PR DESCRIPTION
Hi @nbaksalyar 

### Fixes #9

### Changes 
- Moved the common code from linux to unix module
- Added `cirrus.yml` to test for BSD (`cargo build` and `cargo test`) on Cirrus CI and it [passes ](https://cirrus-ci.com/task/5952871088783360) for FreeBSD12

### Pending Tasks
- [x] Clean the commented code
- [x] Improve the doc Comments
- [ ] Add Cirrus badge to ReadMe.md
