### PR TITLE
Refactor dwarf loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ nix = "0.17.0"
 libproc = "0.7.2"
 libc = "0.2.72"
 object = "0.20"
+rental = "0.5.5"
 
 # Dependencies specific to macOS & Linux
 [target.'cfg(unix)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Headcrab, a modern Rust debugging library.
 
+#[macro_use]
+extern crate rental;
+
 /// Functions to work with target processes: reading & writing memory, process control functions, etc.
 pub mod target;
 


### PR DESCRIPTION
This stores the parsed object and DWARF together with the `Mmap` in `Dwarf` by using the rental crate for self referential structs. This is a prerequisite for lazily parsing debuginfo.