### PR TITLE
Attach to process on linux

### DIFF
--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -28,6 +28,12 @@ impl LinuxTarget {
         Ok(LinuxTarget { pid })
     }
 
+    /// Attaches process as a debugee.
+    pub fn attach(pid: Pid) -> Result<LinuxTarget, Box<dyn std::error::Error>> {
+        unix::attach(pid)?;
+        Ok(LinuxTarget { pid })
+    }
+
     /// Uses this process as a debuggee.
     pub fn me() -> LinuxTarget {
         LinuxTarget { pid: getpid() }

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -40,3 +40,10 @@ pub(crate) fn launch(path: &str) -> Result<Pid, Box<dyn std::error::Error>> {
         }
     }
 }
+
+/// Attach existing process as a debugee.
+pub(crate) fn attach(pid: Pid) -> Result<(), Box<dyn std::error::Error>> {
+    ptrace::attach(pid)?;
+    let _status = waitpid(pid, None);
+    Ok(())
+}

--- a/tests/attach_readmem.rs
+++ b/tests/attach_readmem.rs
@@ -1,15 +1,12 @@
 //! This is a simple test to attach to already running debugee process
 
-use nix::{
-    sys::wait::waitpid,
-    unistd::{execv, fork, ForkResult, Pid},
-};
+use nix::unistd::{execv, fork, ForkResult};
 use std::ffi::CString;
 
 mod test_utils;
 
 #[cfg(target_os = "linux")]
-use headcrab::{symbol::Dwarf, target::LinuxTarget, target::UnixTarget};
+use headcrab::{symbol::Dwarf, target::LinuxTarget};
 
 static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/longer_hello");
 

--- a/tests/attach_readmem.rs
+++ b/tests/attach_readmem.rs
@@ -1,0 +1,57 @@
+//! This is a simple test to attach to already running debugee process
+
+use nix::{
+    sys::wait::waitpid,
+    unistd::{execv, fork, ForkResult, Pid},
+};
+use std::ffi::CString;
+
+mod test_utils;
+
+#[cfg(target_os = "linux")]
+use headcrab::{symbol::Dwarf, target::LinuxTarget, target::UnixTarget};
+
+static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
+
+// Ignoring because most linux distributions have attaching to a running process disabled
+#[ignore]
+#[cfg(target_os = "linux")]
+#[test]
+fn attach_readmem() -> Result<(), Box<dyn std::error::Error>> {
+    test_utils::ensure_testees();
+
+    let debuginfo = Dwarf::new(BIN_PATH)?;
+
+    let str_addr = debuginfo
+        .get_var_address("STATICVAR")
+        .expect("Expected static var has not been found in the target binary");
+
+    match fork()? {
+        ForkResult::Parent { child, .. } => {
+            let target = LinuxTarget::attach(child)?;
+
+            // Read pointer
+            let mut ptr_addr: usize = 0;
+            unsafe {
+                target.read().read(&mut ptr_addr, str_addr).apply()?;
+            }
+
+            // // Read current value
+            // let mut rval = [0u8; 13];
+            // unsafe {
+            //     target.read().read(&mut rval, ptr_addr).apply()?;
+            // }
+
+            // assert_eq!(&rval, b"Hello, world!");
+
+            Ok(())
+        }
+        ForkResult::Child => {
+            let path = CString::new(BIN_PATH)?;
+            execv(&path, &[])?;
+
+            // execv replaces the process image, so this place in code will not be reached.
+            unreachable!();
+        }
+    }
+}

--- a/tests/testees/.gitignore
+++ b/tests/testees/.gitignore
@@ -1,1 +1,2 @@
 /hello
+/longer_hello

--- a/tests/testees/longer_hello.rs
+++ b/tests/testees/longer_hello.rs
@@ -1,0 +1,9 @@
+static STATICVAR: &str = "Hello, world!\n";
+
+pub fn main() {
+
+    use std::{thread, time};
+    thread::sleep(time::Duration::from_millis(100));
+
+    println!("{}", STATICVAR);
+}


### PR DESCRIPTION
Implements attaching to running process on linux. Closes #39. Cannot implement tests because most linux distros have capability to attach to different process disabled.