### PR TITLE
Add disassembler and line info parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 lazy_static = "1.4.0"
 object = "0.20"
 gimli = "0.22.0"
+capstone = "0.7.0"
 
 # Dependencies specific to macOS & Linux
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = "1.4.0"
 object = "0.20"
 gimli = "0.22.0"
 capstone = "0.7.0"
+addr2line = "0.13.0"
 
 # Dependencies specific to macOS & Linux
 [target.'cfg(unix)'.dependencies]

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -341,10 +341,10 @@ impl RelocatedDwarfEntry {
                         let object: &object::File = &parsed.object;
                         object.segments().find_map(|segment: object::Segment| {
                             // Sometimes the offset is just before the start file offset of the segment.
-                            if offset <= segment.file_range().0 {
+                            if offset <= segment.file_range().0 + segment.file_range().1 {
                                 Some((
                                     segment.file_range(),
-                                    segment.address() - (segment.file_range().0 - offset),
+                                    segment.address() - segment.file_range().0 + offset,
                                 ))
                             } else {
                                 None

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -16,6 +16,10 @@ use std::{
     rc::Rc,
 };
 
+mod source;
+
+pub use source::DisassemblySource;
+
 macro_rules! dwarf_attr_or_continue {
     (str($dwarf:ident,$unit:ident) $entry:ident.$name:ident) => {
         $dwarf

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -148,9 +148,7 @@ impl<'a> ParsedDwarf<'a> {
                         return false;
                     }
                 }
-                !symbol.is_undefined()
-                    && symbol.section() != object::SymbolSection::Common
-                    && symbol.size() > 0
+                !symbol.is_undefined() && symbol.section() != object::SymbolSection::Common
             })
             .collect();
         symbols.sort_by_key(|sym| sym.address());

--- a/src/symbol/source.rs
+++ b/src/symbol/source.rs
@@ -1,0 +1,42 @@
+use capstone::Capstone;
+
+pub struct DisassemblySource(Capstone);
+
+impl DisassemblySource {
+    pub fn new() -> Self {
+        use capstone::arch::{BuildsCapstone, BuildsCapstoneSyntax};
+
+        let cs = Capstone::new()
+            .x86()
+            .mode(capstone::arch::x86::ArchMode::Mode64)
+            .syntax(capstone::arch::x86::ArchSyntax::Att)
+            .detail(true)
+            .build()
+            .unwrap();
+
+        DisassemblySource(cs)
+    }
+
+    pub fn source_snippet(
+        &self,
+        bytes: &[u8],
+        addr: u64,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        use std::fmt::Write;
+
+        let mut fmt = String::new();
+
+        for insn in self.0.disasm_all(&bytes, addr).unwrap().iter() {
+            if let Some(mnemonic) = insn.mnemonic() {
+                write!(fmt, "{} ", mnemonic).unwrap();
+                if let Some(op_str) = insn.op_str() {
+                    writeln!(fmt, "{}", op_str).unwrap();
+                } else {
+                    fmt.push('\n');
+                }
+            }
+        }
+
+        Ok(fmt)
+    }
+}

--- a/src/symbol/source.rs
+++ b/src/symbol/source.rs
@@ -21,12 +21,16 @@ impl DisassemblySource {
         &self,
         bytes: &[u8],
         addr: u64,
+        show_address: bool,
     ) -> Result<String, Box<dyn std::error::Error>> {
         use std::fmt::Write;
 
         let mut fmt = String::new();
 
         for insn in self.0.disasm_all(&bytes, addr).unwrap().iter() {
+            if show_address {
+                write!(fmt, "0x{:016x}: ", insn.address()).unwrap();
+            }
             if let Some(mnemonic) = insn.mnemonic() {
                 write!(fmt, "{} ", mnemonic).unwrap();
                 if let Some(op_str) = insn.op_str() {

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -5,6 +5,7 @@ use nix::unistd::{getpid, Pid};
 use procfs::process::{Process, Task};
 use procfs::ProcError;
 use std::{
+    ffi::CString,
     fs::File,
     io::{BufRead, BufReader},
     marker::PhantomData,
@@ -68,7 +69,7 @@ impl LinuxTarget {
     pub fn launch(
         path: &str,
     ) -> Result<(LinuxTarget, nix::sys::wait::WaitStatus), Box<dyn std::error::Error>> {
-        let (pid, status) = unix::launch(path)?;
+        let (pid, status) = unix::launch(CString::new(path)?)?;
         let target = LinuxTarget { pid };
         target.kill_on_exit()?;
         Ok((target, status))

--- a/tests/disassemble.rs
+++ b/tests/disassemble.rs
@@ -1,0 +1,57 @@
+//! This is a simple test to disassemble bytes from a child process.
+
+mod test_utils;
+
+#[cfg(target_os = "linux")]
+use headcrab::{symbol::RelocatedDwarf, target::UnixTarget};
+
+static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/known_asm");
+
+// FIXME: this should be an internal impl detail
+#[cfg(target_os = "macos")]
+static MAC_DSYM_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/testees/known_asm.dSYM/Contents/Resources/DWARF/known_asm"
+);
+
+// FIXME: Running this test just for linux because of privileges issue on macOS. Enable for everything after fixing.
+#[cfg(target_os = "linux")]
+#[test]
+fn disassemble() -> Result<(), Box<dyn std::error::Error>> {
+    test_utils::ensure_testees();
+
+    let target = test_utils::launch(BIN_PATH);
+    let debuginfo = RelocatedDwarf::from_maps(&target.memory_maps()?)?;
+
+    // First breakpoint
+    target.unpause()?;
+    let ip = target.read_regs()?.rip;
+    println!("{:08x}", ip);
+    assert_eq!(
+        debuginfo.get_address_symbol_name(ip as usize).as_deref(),
+        Some("main")
+    );
+
+    dbg!();
+    let mut code = [0; 10];
+    unsafe {
+        target.read().read(&mut code, ip as usize).apply()?;
+    }
+    dbg!();
+
+    let disassembly = headcrab::symbol::DisassemblySource::new().source_snippet(&code, ip)?;
+    assert_eq!(
+        disassembly,
+        "nop \n\
+int3 \n\
+movq $0, %rax\n\
+retq \n"
+    );
+
+    // Second breakpoint
+    target.unpause()?;
+
+    test_utils::continue_to_end(&target);
+
+    Ok(())
+}

--- a/tests/disassemble.rs
+++ b/tests/disassemble.rs
@@ -39,7 +39,8 @@ fn disassemble() -> Result<(), Box<dyn std::error::Error>> {
     }
     dbg!();
 
-    let disassembly = headcrab::symbol::DisassemblySource::new().source_snippet(&code, ip)?;
+    let disassembly =
+        headcrab::symbol::DisassemblySource::new().source_snippet(&code, ip, false)?;
     assert_eq!(
         disassembly,
         "nop \n\

--- a/tests/fixed_breakpoint.rs
+++ b/tests/fixed_breakpoint.rs
@@ -1,0 +1,46 @@
+//! This is a simple test for waiting for a fixed breakpoint in a child process.
+
+mod test_utils;
+
+#[cfg(target_os = "linux")]
+use headcrab::{symbol::RelocatedDwarf, target::UnixTarget};
+
+static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/known_asm");
+
+// FIXME: this should be an internal impl detail
+#[cfg(target_os = "macos")]
+static MAC_DSYM_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/testees/known_asm.dSYM/Contents/Resources/DWARF/known_asm"
+);
+
+// FIXME: Running this test just for linux because of privileges issue on macOS. Enable for everything after fixing.
+#[cfg(target_os = "linux")]
+#[test]
+fn fixed_breakpoint() -> Result<(), Box<dyn std::error::Error>> {
+    test_utils::ensure_testees();
+
+    let target = test_utils::launch(BIN_PATH);
+
+    let debuginfo = RelocatedDwarf::from_maps(&target.memory_maps()?)?;
+
+    // First breakpoint
+    target.unpause()?;
+    let ip = target.read_regs()?.rip;
+    assert_eq!(
+        debuginfo.get_address_symbol_name(ip as usize).as_deref(),
+        Some("main")
+    );
+
+    // Second breakpoint
+    target.unpause()?;
+    let ip = target.read_regs()?.rip;
+    assert_eq!(
+        debuginfo.get_address_symbol_name(ip as usize).as_deref(),
+        Some("main")
+    );
+
+    test_utils::continue_to_end(&target);
+
+    Ok(())
+}

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -1,0 +1,43 @@
+//! This is a simple test to get the source line from a child process.
+
+mod test_utils;
+
+#[cfg(target_os = "linux")]
+use headcrab::{symbol::RelocatedDwarf, target::UnixTarget};
+
+static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
+
+// FIXME: this should be an internal impl detail
+#[cfg(target_os = "macos")]
+static MAC_DSYM_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/testees/hello.dSYM/Contents/Resources/DWARF/hello"
+);
+
+// FIXME: Running this test just for linux because of privileges issue on macOS. Enable for everything after fixing.
+#[cfg(target_os = "linux")]
+#[test]
+fn source() -> Result<(), Box<dyn std::error::Error>> {
+    test_utils::ensure_testees();
+
+    let target = test_utils::launch(BIN_PATH);
+    let debuginfo = RelocatedDwarf::from_maps(&target.memory_maps()?)?;
+
+    test_utils::patch_breakpoint(&target, &debuginfo);
+
+    // First breakpoint
+    target.unpause()?;
+    let ip = target.read_regs()?.rip;
+    println!("{:08x}", ip);
+    assert_eq!(
+        debuginfo.get_address_symbol_name(ip as usize).as_deref(),
+        Some("breakpoint")
+    );
+
+    let source_location = debuginfo.source_location(ip as usize)?.unwrap();
+    assert!(source_location.0.ends_with("x86/sse2.rs"));
+
+    test_utils::continue_to_end(&target);
+
+    Ok(())
+}

--- a/tests/testees/.gitignore
+++ b/tests/testees/.gitignore
@@ -1,2 +1,3 @@
 /hello
 /longer_hello
+/known_asm

--- a/tests/testees/Makefile
+++ b/tests/testees/Makefile
@@ -1,13 +1,22 @@
 CC       = rustc
 CC_FLAGS = -g -Copt-level=2 -Cforce-frame-pointers=yes
-SRCS = $(wildcard *.rs)
-BINS = $(patsubst %.rs,%,$(SRCS))
+AS       = as
+AS_FLAGS =
+LD       = gcc
+LD_FLAGS =
+SRCS = $(wildcard *.rs) $(wildcard *.S)
+BINS = $(patsubst %.S,%,$(patsubst %.rs,%,$(SRCS)))
 
 .PHONY: all
 all: $(BINS)
 
 %: %.rs
 	$(CC) $(CC_FLAGS) -o $@ $^
+
+%: %.S
+	$(AS) $(AS_FLAGS) -o $@.o $^
+	$(LD) $(LD_FLAGS) -o $@ $@.o
+	rm $@.o
 
 clean:
 	rm -f $(BINS)

--- a/tests/testees/known_asm.S
+++ b/tests/testees/known_asm.S
@@ -1,0 +1,9 @@
+.globl main
+main:
+    # Breakpoint trap on Linux
+    # FIXME use right interrupt on macOS
+    int $3
+    nop
+    int $3
+    mov $0, %rax
+    ret


### PR DESCRIPTION
Blocked on https://github.com/gimli-rs/addr2line/issues/187 to get addr2line working files compiled from assembly. Otherwise the line info test fails.