### PR TITLE
More execution commands and use waitpid where sensible

### DIFF
--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -23,15 +23,19 @@ impl UnixTarget for LinuxTarget {
 
 impl LinuxTarget {
     /// Launches a new debuggee process
-    pub fn launch(path: &str) -> Result<LinuxTarget, Box<dyn std::error::Error>> {
-        let pid = unix::launch(path)?;
-        Ok(LinuxTarget { pid })
+    pub fn launch(
+        path: &str,
+    ) -> Result<(LinuxTarget, nix::sys::wait::WaitStatus), Box<dyn std::error::Error>> {
+        let (pid, status) = unix::launch(path)?;
+        Ok((LinuxTarget { pid }, status))
     }
 
     /// Attaches process as a debugee.
-    pub fn attach(pid: Pid) -> Result<LinuxTarget, Box<dyn std::error::Error>> {
-        unix::attach(pid)?;
-        Ok(LinuxTarget { pid })
+    pub fn attach(
+        pid: Pid,
+    ) -> Result<(LinuxTarget, nix::sys::wait::WaitStatus), Box<dyn std::error::Error>> {
+        let status = unix::attach(pid)?;
+        Ok((LinuxTarget { pid }, status))
     }
 
     /// Uses this process as a debuggee.

--- a/src/target/macos/mod.rs
+++ b/src/target/macos/mod.rs
@@ -93,12 +93,6 @@ impl Target {
         })
     }
 
-    /// Continues execution of a debuggee.
-    pub fn unpause(&self) -> Result<(), Box<dyn std::error::Error>> {
-        signal::kill(self.pid, Signal::SIGCONT)?;
-        Ok(())
-    }
-
     /// Returns a list of maps in the debuggee's virtual adddress space.
     pub fn get_addr_range(&self) -> Result<usize, Box<dyn std::error::Error>> {
         let regs = vmmap::macosx_debug_regions(self.pid, self.port);

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -24,7 +24,7 @@ pub trait UnixTarget {
         Ok(status)
     }
 
-    /// Detach from the debuggee, continuing it's execution.
+    /// Detach from the debuggee, continuing its execution.
     fn detach(&self) -> Result<(), Box<dyn std::error::Error>> {
         ptrace::detach(self.pid(), None)?;
         Ok(())

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -1,6 +1,6 @@
 use nix::{
     sys::ptrace,
-    sys::wait::waitpid,
+    sys::wait::{waitpid, WaitStatus},
     unistd::{execv, fork, ForkResult, Pid},
 };
 use std::ffi::CString;
@@ -10,25 +10,45 @@ pub trait UnixTarget {
     /// Provides the Pid of the debugee process
     fn pid(&self) -> Pid;
 
+    /// Step the debuggee one instruction further.
+    fn step(&self) -> Result<WaitStatus, Box<dyn std::error::Error>> {
+        ptrace::step(self.pid(), None)?;
+        let status = waitpid(self.pid(), None)?;
+        Ok(status)
+    }
+
     /// Continues execution of a debuggee.
-    fn unpause(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn unpause(&self) -> Result<WaitStatus, Box<dyn std::error::Error>> {
         ptrace::cont(self.pid(), None)?;
-        waitpid(self.pid(), None).unwrap();
+        let status = waitpid(self.pid(), None)?;
+        Ok(status)
+    }
+
+    /// Detach from the debuggee, continuing it's execution.
+    fn detach(&self) -> Result<(), Box<dyn std::error::Error>> {
+        ptrace::detach(self.pid(), None)?;
         Ok(())
+    }
+
+    /// Kills the debuggee.
+    fn kill(&self) -> Result<WaitStatus, Box<dyn std::error::Error>> {
+        ptrace::kill(self.pid())?;
+        let status = waitpid(self.pid(), None)?;
+        Ok(status)
     }
 }
 
 /// Launch a new debuggee process.
-pub(crate) fn launch(path: &str) -> Result<Pid, Box<dyn std::error::Error>> {
+pub(in crate::target) fn launch(
+    path: &str,
+) -> Result<(Pid, WaitStatus), Box<dyn std::error::Error>> {
     // We start the debuggee by forking the parent process.
     // The child process invokes `ptrace(2)` with the `PTRACE_TRACEME` parameter to enable debugging features for the parent.
     // This requires a user to have a `SYS_CAP_PTRACE` permission. See `man capabilities(7)` for more information.
     match fork()? {
         ForkResult::Parent { child, .. } => {
-            let _status = waitpid(child, None);
-
-            // todo: handle this properly
-            Ok(child)
+            let status = waitpid(child, None)?;
+            Ok((child, status))
         }
         ForkResult::Child => {
             ptrace::traceme()?;
@@ -50,8 +70,8 @@ pub(crate) fn launch(path: &str) -> Result<Pid, Box<dyn std::error::Error>> {
 }
 
 /// Attach existing process as a debugee.
-pub(crate) fn attach(pid: Pid) -> Result<(), Box<dyn std::error::Error>> {
+pub(in crate::target) fn attach(pid: Pid) -> Result<WaitStatus, Box<dyn std::error::Error>> {
     ptrace::attach(pid)?;
-    let _status = waitpid(pid, None);
-    Ok(())
+    let status = waitpid(pid, None)?;
+    Ok(status)
 }

--- a/tests/attach_readmem.rs
+++ b/tests/attach_readmem.rs
@@ -29,7 +29,11 @@ fn attach_readmem() -> Result<(), Box<dyn std::error::Error>> {
             use std::{thread, time};
             thread::sleep(time::Duration::from_millis(50));
 
-            let target = LinuxTarget::attach(child)?;
+            let (target, status) = LinuxTarget::attach(child)?;
+            match status {
+                nix::sys::wait::WaitStatus::Stopped(_, nix::sys::signal::SIGTRAP) => {}
+                _ => panic!("Status: {:?}", status),
+            }
 
             // Read pointer
             let mut ptr_addr: usize = 0;

--- a/tests/readmem.rs
+++ b/tests/readmem.rs
@@ -3,7 +3,7 @@
 mod test_utils;
 
 #[cfg(target_os = "linux")]
-use headcrab::{symbol::RelocatedDwarf, target::LinuxTarget, target::UnixTarget};
+use headcrab::{symbol::RelocatedDwarf, target::UnixTarget};
 
 static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
 
@@ -20,7 +20,7 @@ static MAC_DSYM_PATH: &str = concat!(
 fn read_memory() -> Result<(), Box<dyn std::error::Error>> {
     test_utils::ensure_testees();
 
-    let target = LinuxTarget::launch(BIN_PATH)?;
+    let target = test_utils::launch(BIN_PATH);
 
     println!("{:#?}", target.memory_maps()?);
     let debuginfo = RelocatedDwarf::from_maps(&target.memory_maps()?)?;
@@ -105,7 +105,7 @@ fn read_memory() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&rval, b"Hello, world!");
 
-    target.unpause()?;
+    test_utils::continue_to_end(&target);
 
     Ok(())
 }

--- a/tests/readregs.rs
+++ b/tests/readregs.rs
@@ -2,9 +2,6 @@
 
 mod test_utils;
 
-#[cfg(target_os = "linux")]
-use headcrab::{target::LinuxTarget, target::UnixTarget};
-
 static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -12,7 +9,7 @@ static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hell
 fn read_regs() -> Result<(), Box<dyn std::error::Error>> {
     test_utils::ensure_testees();
 
-    let target = LinuxTarget::launch(BIN_PATH)?;
+    let target = test_utils::launch(BIN_PATH);
 
     let regs = target.read_regs()?;
 
@@ -53,7 +50,7 @@ fn read_regs() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(regs.fs, 0);
     assert_eq!(regs.gs, 0);
 
-    target.unpause()?;
+    test_utils::continue_to_end(&target);
 
     Ok(())
 }

--- a/tests/syscall.rs
+++ b/tests/syscall.rs
@@ -3,7 +3,7 @@
 mod test_utils;
 
 #[cfg(target_os = "linux")]
-use headcrab::{target::LinuxTarget, target::UnixTarget};
+use headcrab::target::UnixTarget;
 
 static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
 
@@ -13,7 +13,7 @@ static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hell
 fn syscall() -> Result<(), Box<dyn std::error::Error>> {
     test_utils::ensure_testees();
 
-    let target = LinuxTarget::launch(BIN_PATH)?;
+    let target = test_utils::launch(BIN_PATH);
 
     println!(
         "{}\n",
@@ -34,7 +34,7 @@ fn syscall() -> Result<(), Box<dyn std::error::Error>> {
     for line in std::fs::read_to_string(format!("/proc/{}/maps", target.pid()))?.lines() {
         if line.starts_with(&format!("{:08x}-", addr)) {
             // Found mapped addr
-            target.unpause()?;
+            test_utils::continue_to_end(&target);
             return Ok(());
         }
     }


### PR DESCRIPTION
While there are legitimate use cases where waitpid should not be used, not using it will in most cases lead to race-conditions between stopping execution of the debuggee again and reading/writing state.