### PR TITLE
Kill debugee on debugger exit

### DIFF
--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -27,7 +27,9 @@ impl LinuxTarget {
         path: &str,
     ) -> Result<(LinuxTarget, nix::sys::wait::WaitStatus), Box<dyn std::error::Error>> {
         let (pid, status) = unix::launch(path)?;
-        Ok((LinuxTarget { pid }, status))
+        let target = LinuxTarget { pid };
+        target.kill_on_exit()?;
+        Ok((target, status))
     }
 
     /// Attaches process as a debugee.

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -143,6 +143,12 @@ impl LinuxTarget {
             })
             .collect())
     }
+
+    /// Kill debuggee when debugger exits.
+    fn kill_on_exit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        nix::sys::ptrace::setoptions(self.pid, nix::sys::ptrace::Options::PTRACE_O_EXITKILL)?;
+        Ok(())
+    }
 }
 
 /// A single memory read operation.

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -36,12 +36,6 @@ pub trait UnixTarget {
         let status = waitpid(self.pid(), None)?;
         Ok(status)
     }
-
-    /// Kill debuggee when debugger exits.
-    fn kill_on_exit(&self) -> Result<(), Box<dyn std::error::Error>> {
-        ptrace::setoptions(self.pid(), ptrace::Options::PTRACE_O_EXITKILL)?;
-        Ok(())
-    }
 }
 
 /// Launch a new debuggee process.

--- a/src/target/unix.rs
+++ b/src/target/unix.rs
@@ -36,6 +36,12 @@ pub trait UnixTarget {
         let status = waitpid(self.pid(), None)?;
         Ok(status)
     }
+
+    /// Kill debuggee when debugger exits.
+    fn kill_on_exit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        ptrace::setoptions(self.pid(), ptrace::Options::PTRACE_O_EXITKILL)?;
+        Ok(())
+    }
 }
 
 /// Launch a new debuggee process.
@@ -48,6 +54,7 @@ pub(in crate::target) fn launch(
     match fork()? {
         ForkResult::Parent { child, .. } => {
             let status = waitpid(child, None)?;
+
             Ok((child, status))
         }
         ForkResult::Child => {


### PR DESCRIPTION
Closes #48. If debugee was launched by debugger it is killed when debugger exits.