### PR TITLE
Fix spelling in comments and variable names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 //! Headcrab, a modern Rust debugging library.
 
-#[macro_use]
-extern crate lazy_static;
-
 /// Functions to work with target processes: reading & writing memory, process control functions, etc.
 pub mod target;
 

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -70,7 +70,7 @@ pub struct ParsedDwarf<'a> {
 
 impl<'a> ParsedDwarf<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<ParsedDwarf<'a>, Box<dyn std::error::Error>> {
-        // This is completely inefficient and hacky code, but currently it serves the only
+        // This is completely inefficient and hackish code, but currently it serves the only
         // purpose of getting addresses of static variables.
         // TODO: this will be reworked in a more complete symbolication framework.
 

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -51,7 +51,7 @@ pub struct LinuxTarget {
 }
 
 impl UnixTarget for LinuxTarget {
-    /// Provides the Pid of the debugee process
+    /// Provides the Pid of the debuggee process
     fn pid(&self) -> Pid {
         self.pid
     }
@@ -68,7 +68,7 @@ impl LinuxTarget {
         Ok((target, status))
     }
 
-    /// Attaches process as a debugee.
+    /// Attaches process as a debuggee.
     pub fn attach(
         pid: Pid,
     ) -> Result<(LinuxTarget, nix::sys::wait::WaitStatus), Box<dyn std::error::Error>> {
@@ -193,7 +193,7 @@ impl LinuxTarget {
         Ok(())
     }
 
-    /// Returns the current snapshot view of this debugee process threads.
+    /// Returns the current snapshot view of this debuggee process threads.
     pub fn threads(
         &self,
     ) -> Result<Vec<Box<dyn Thread<ThreadId = i32>>>, Box<dyn std::error::Error>> {
@@ -455,10 +455,10 @@ impl<'a> ReadMemory<'a> {
 /// This can be useful for calculation of relative addresses in memory.
 pub fn get_addr_range(pid: Pid) -> Result<usize, Box<dyn std::error::Error>> {
     let file = File::open(format!("/proc/{}/maps", pid))?;
-    let mut bufread = BufReader::new(file);
+    let mut buf_read = BufReader::new(file);
     let mut proc_map = String::new();
 
-    bufread.read_line(&mut proc_map)?;
+    buf_read.read_line(&mut proc_map)?;
 
     let proc_data: Vec<_> = proc_map.split(' ').collect();
     let addr_range: Vec<_> = proc_data[0].split('-').collect();
@@ -496,7 +496,7 @@ mod tests {
                 .read(&mut read_var_op, &var as *const _ as usize)
                 .read(&mut read_var2_op, &var2 as *const _ as usize)
                 .apply()
-                .expect("Failed to apply memop");
+                .expect("Failed to apply mem_op");
         }
 
         assert_eq!(read_var2_op, var2);
@@ -604,7 +604,7 @@ mod tests {
                         .read()
                         .read(&mut read_var_op, array_ptr as *const _ as usize)
                         .apply()
-                        .expect("Failed to apply memop");
+                        .expect("Failed to apply mem_op");
 
                     for i in 0..PAGE_SIZE + 2 {
                         assert_eq!(var[i], read_var_op[i]);

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -11,7 +11,7 @@ use std::{
     mem,
 };
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref PAGE_SIZE: usize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize };
 }
 


### PR DESCRIPTION
This makes my spellchecker happy, so that I can use it to avoid
adding more typos in the future:-)