### PR TITLE
Make threads test more robust

### DIFF
--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -417,7 +417,14 @@ mod tests {
 
         let threads: Vec<_> = threads
             .iter()
-            .map(|t| (t.name().unwrap().unwrap().clone(), t.thread_id()))
+            .map(|t| {
+                let name = match t.name() {
+                    Ok(Some(name)) => name,
+                    Ok(None) => "".to_string(),
+                    Err(err) => err.to_string(),
+                };
+                (name, t.thread_id())
+            })
             .collect();
 
         assert!(

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -418,7 +418,7 @@ mod tests {
         let threads: Vec<_> = threads
             .iter()
             .map(|t| {
-                let name = t.name().unwrap().unwrap_or("".to_string());
+                let name = t.name().unwrap().unwrap_or_else(String::new);
                 let id = t.thread_id();
                 (name, id)
             })

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -418,12 +418,9 @@ mod tests {
         let threads: Vec<_> = threads
             .iter()
             .map(|t| {
-                let name = match t.name() {
-                    Ok(Some(name)) => name,
-                    Ok(None) => "".to_string(),
-                    Err(err) => err.to_string(),
-                };
-                (name, t.thread_id())
+                let name = t.name().unwrap().unwrap_or("".to_string());
+                let id = t.thread_id();
+                (name, id)
             })
             .collect();
 


### PR DESCRIPTION
Fixes #80  

Can handle the failure to obtain the name of a thread. This might
happen for different reasons (e.g., maybe the thread is not there
anymore). I'm keeping the error as the name to show in the assertions
failures.