### PR TITLE
Inject code into the debugged process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,5 @@ winapi = { version = "0.3.9", features = ["winuser","processthreadsapi","winbase
 [dev-dependencies]
 rustyline = "6.2.0"
 repl_tools = { path = "./repl_tools" }
+cranelift-codegen = "0.66.0"
+cranelift-reader = "0.66.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ winapi = { version = "0.3.9", features = ["winuser","processthreadsapi","winbase
 [dev-dependencies]
 rustyline = "6.2.0"
 repl_tools = { path = "./repl_tools" }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 headcrab_inject = { path = "./headcrab_inject" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,6 @@ winapi = { version = "0.3.9", features = ["winuser","processthreadsapi","winbase
 [dev-dependencies]
 rustyline = "6.2.0"
 repl_tools = { path = "./repl_tools" }
-cranelift-codegen = "0.66.0"
-cranelift-reader = "0.66.0"
+headcrab_inject = { path = "./headcrab_inject" }
+
+[workspace]

--- a/examples/inject_dylib.clif
+++ b/examples/inject_dylib.clif
@@ -1,0 +1,18 @@
+function u0:2() system_v {
+    gv0 = symbol u1:0 ; dylib file name
+    gv1 = symbol u1:1 ; __headcrab_command
+    sig0 = (i64, i32) -> i64 system_v ; fn(filename: *const c_char, flag: c_int) -> *mut c_void
+    sig1 = (i64, i64) -> i64 system_v ; fn(handle: *mut c_void, symbol: *const c_char) -> *mut c_void
+    sig2 = () system_v ; signature for __headcrab_command
+    fn0 = u0:0 sig0 ; dlopen
+    fn1 = u0:1 sig1 ; dlsym
+
+block0:
+    v0 = global_value.i64 gv0
+    v1 = iconst.i32 0x2 ; RTLD_NOW
+    v2 = call fn0(v0, v1)
+    v3 = global_value.i64 gv1
+    v4 = call fn1(v2, v3)
+    call_indirect sig2, v4()
+    return
+}

--- a/examples/inject_hello_world.clif
+++ b/examples/inject_hello_world.clif
@@ -2,7 +2,7 @@
 ; define: data0 "Hello World from injected code!\n\0"
 
 function u0:1() system_v {
-    gv0 = symbol colocated u1:0
+    gv0 = symbol u1:0
     sig0 = (i64) system_v
     fn0 = u0:0 sig0
 

--- a/examples/inject_hello_world.clif
+++ b/examples/inject_hello_world.clif
@@ -1,5 +1,5 @@
 ; declare: func0 puts
-; define: data0 "Hello World from injected code!\n\0"
+; define: data0 "Hello World from injected code!\0"
 
 function u0:1() system_v {
     gv0 = symbol u1:0

--- a/examples/inject_hello_world.clif
+++ b/examples/inject_hello_world.clif
@@ -1,5 +1,6 @@
-; data0: "Hello World from injected code!\n\0"
-; func0: puts
+; declare: func0 puts
+; define: data0 "Hello World from injected code!\n\0"
+
 function u0:1() system_v {
     gv0 = symbol colocated u1:0
     sig0 = (i64) system_v
@@ -10,3 +11,15 @@ block0:
     call fn0(v0)
     return
 }
+
+function u0:2() system_v {
+    sig0 = () system_v
+    fn0 = u0:1 sig0
+
+block0:
+    call fn0()
+    debugtrap
+    return
+}
+
+; run: func2

--- a/examples/inject_hello_world.clif
+++ b/examples/inject_hello_world.clif
@@ -1,0 +1,12 @@
+; data0: "Hello World from injected code!\n\0"
+; func0: puts
+function u0:1() system_v {
+    gv0 = symbol colocated u1:0
+    sig0 = (i64) system_v
+    fn0 = u0:0 sig0
+
+block0:
+    v0 = global_value.i64 gv0
+    call fn0(v0)
+    return
+}

--- a/examples/inject_hello_world.clif
+++ b/examples/inject_hello_world.clif
@@ -18,7 +18,6 @@ function u0:2() system_v {
 
 block0:
     call fn0()
-    debugtrap
     return
 }
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -47,7 +47,7 @@ mod example {
         /// Print this help
         Help|h: (),
         /// Inject and run clif ir
-        Inject: (),
+        Inject: PathBuf,
         /// Exit
         Exit|quit|q: (),
     });
@@ -286,12 +286,14 @@ mod example {
             ReplCommand::Locals(()) => {
                 return show_locals(context);
             }
-            ReplCommand::Inject(()) => {
+            ReplCommand::Inject(file) => {
                 context.load_debuginfo_if_necessary()?;
 
-                return headcrab_inject::inject_clif_code(context.remote()?, &|sym| {
-                    context.debuginfo().get_symbol_address(sym).unwrap() as u64
-                });
+                return headcrab_inject::inject_clif_code(
+                    context.remote()?,
+                    &|sym| context.debuginfo().get_symbol_address(sym).unwrap() as u64,
+                    &std::fs::read_to_string(file)?,
+                );
             }
             ReplCommand::Exit(()) => unreachable!("Should be handled earlier"),
         }

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -287,8 +287,6 @@ mod example {
                 return show_locals(context);
             }
             ReplCommand::Inject(()) => {
-                println!("WIP");
-
                 context.load_debuginfo_if_necessary()?;
 
                 return headcrab_inject::inject_clif_code(

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -82,10 +82,9 @@ mod example {
         }
 
         fn load_debuginfo_if_necessary(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-            //if self.debuginfo.is_none() {
+            // FIXME only reload debuginfo when necessary (memory map changed)
             let memory_maps = self.remote()?.memory_maps()?;
             self.debuginfo = Some(RelocatedDwarf::from_maps(&memory_maps)?);
-            //}
             Ok(())
         }
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -20,7 +20,9 @@ mod example {
         target::{AttachOptions, LinuxTarget, UnixTarget},
     };
 
+    #[cfg(target_os = "linux")]
     use headcrab_inject::{compile_clif_code, DataId, FuncId, InjectionContext};
+
     use repl_tools::HighlightAndComplete;
     use rustyline::CompletionType;
 
@@ -616,6 +618,17 @@ mod example {
         Ok(())
     }
 
+    #[cfg(not(target_os = "linux"))]
+    fn inject_clif(
+        _context: &mut Context,
+        _file: PathBuf,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err("injectclif is currently only supported on Linux"
+            .to_string()
+            .into())
+    }
+
+    #[cfg(target_os = "linux")]
     fn inject_clif(context: &mut Context, file: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         context.load_debuginfo_if_necessary()?;
 
@@ -651,6 +664,17 @@ mod example {
         Ok(())
     }
 
+    #[cfg(not(target_os = "linux"))]
+    fn inject_lib(
+        _context: &mut Context,
+        _file: PathBuf,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err("injectclif is currently only supported on Linux"
+            .to_string()
+            .into())
+    }
+
+    #[cfg(target_os = "linux")]
     fn inject_lib(context: &mut Context, file: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         context.load_debuginfo_if_necessary()?;
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -77,8 +77,8 @@ mod example {
 
         fn load_debuginfo_if_necessary(&mut self) -> Result<(), Box<dyn std::error::Error>> {
             //if self.debuginfo.is_none() {
-                let memory_maps = self.remote()?.memory_maps()?;
-                self.debuginfo = Some(RelocatedDwarf::from_maps(&memory_maps)?);
+            let memory_maps = self.remote()?.memory_maps()?;
+            self.debuginfo = Some(RelocatedDwarf::from_maps(&memory_maps)?);
             //}
             Ok(())
         }
@@ -291,165 +291,10 @@ mod example {
 
                 context.load_debuginfo_if_necessary()?;
 
-                let functions = cranelift_reader::parse_functions(
-                    r#"
-                target x86_64-unknown-linux-gnu haswell
-
-                function u0:0() system_v {
-                    gv0 = symbol colocated u1:0
-                    sig0 = (i64) system_v
-                    fn0 = u0:0 sig0
-
-                block0:
-                    v0 = global_value.i64 gv0
-                    call fn0(v0)
-                    return
-                }
-                "#,
-                )
-                .unwrap();
-                assert!(functions.len() == 1);
-                println!("{}", functions[0]);
-
-                let flags_builder = cranelift_codegen::settings::builder();
-                let flags = cranelift_codegen::settings::Flags::new(flags_builder);
-                let isa = cranelift_codegen::isa::lookup("x86_64".parse().unwrap())
-                    .unwrap()
-                    .finish(flags);
-
-                #[derive(Default)]
-                struct MyRelocSink(
-                    Vec<(
-                        cranelift_codegen::binemit::CodeOffset,
-                        cranelift_codegen::binemit::Reloc,
-                        cranelift_codegen::ir::ExternalName,
-                        cranelift_codegen::binemit::Addend,
-                    )>,
+                return headcrab_inject::inject_clif_code(
+                    context.remote()?,
+                    context.debuginfo().get_symbol_address("puts").unwrap() as u64,
                 );
-
-                impl cranelift_codegen::binemit::RelocSink for MyRelocSink {
-                    fn reloc_block(
-                        &mut self,
-                        _: cranelift_codegen::binemit::CodeOffset,
-                        _: cranelift_codegen::binemit::Reloc,
-                        _: cranelift_codegen::binemit::CodeOffset,
-                    ) {
-                        todo!()
-                    }
-                    fn reloc_external(
-                        &mut self,
-                        offset: cranelift_codegen::binemit::CodeOffset,
-                        _: cranelift_codegen::ir::SourceLoc,
-                        reloc: cranelift_codegen::binemit::Reloc,
-                        name: &cranelift_codegen::ir::ExternalName,
-                        addend: cranelift_codegen::binemit::Addend,
-                    ) {
-                        self.0.push((offset, reloc, name.clone(), addend));
-                    }
-                    fn reloc_constant(
-                        &mut self,
-                        _: cranelift_codegen::binemit::CodeOffset,
-                        _: cranelift_codegen::binemit::Reloc,
-                        _: cranelift_codegen::ir::ConstantOffset,
-                    ) {
-                        todo!()
-                    }
-                    fn reloc_jt(
-                        &mut self,
-                        _: cranelift_codegen::binemit::CodeOffset,
-                        _: cranelift_codegen::binemit::Reloc,
-                        _: cranelift_codegen::ir::entities::JumpTable,
-                    ) {
-                        todo!()
-                    }
-                }
-
-                let mut code_mem = Vec::new();
-                let mut relocs = MyRelocSink::default();
-
-                let mut ctx = cranelift_codegen::Context::new();
-                ctx.func = functions.into_iter().next().unwrap();
-                ctx.compile_and_emit(
-                    &*isa,
-                    &mut code_mem,
-                    &mut relocs,
-                    &mut cranelift_codegen::binemit::NullTrapSink {},
-                    &mut cranelift_codegen::binemit::NullStackmapSink {},
-                )
-                .unwrap();
-                println!("{}", ctx.func);
-                println!("{:?}", relocs.0);
-
-                let code_region = context.remote()?.mmap(
-                    0 as *mut _,
-                    code_mem.len(),
-                    libc::PROT_READ | libc::PROT_EXEC,
-                    libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
-                    0,
-                    0,
-                )?;
-                let rodata_region = context.remote()?.mmap(
-                    0 as *mut _,
-                    "Hello World from injected code!\n\0".len(),
-                    libc::PROT_READ,
-                    libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
-                    0,
-                    0,
-                )?;
-                let stack_region = context.remote()?.mmap(
-                    0 as *mut _,
-                    0x1000,
-                    libc::PROT_READ | libc::PROT_WRITE,
-                    libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
-                    0,
-                    0,
-                )?;
-                println!(
-                    "code: 0x{:016x} stack: 0x{:016x}",
-                    code_region, stack_region
-                );
-
-                for (offset, reloc, name, addend) in relocs.0 {
-                    let sym = match name {
-                        cranelift_codegen::ir::ExternalName::User {
-                            namespace: 0,
-                            index: 0,
-                        } => {
-                            // puts
-                            context.debuginfo().get_symbol_address("puts").unwrap() as u64
-                        }
-                        cranelift_codegen::ir::ExternalName::User {
-                            namespace: 1,
-                            index: 0,
-                        } => rodata_region,
-                        _ => todo!("{:?}", name),
-                    };
-                    match reloc {
-                        cranelift_codegen::binemit::Reloc::Abs8 => {
-                            code_mem[offset as usize..offset as usize + 8].copy_from_slice(&u64::to_ne_bytes((sym as i64 + addend) as u64));
-                        }
-                        _ => todo!("{:?}", reloc),
-                    }
-                }
-
-                context
-                    .remote()?
-                    .write()
-                    .write_slice(&code_mem, code_region as usize)
-                    .write_slice("Hello World from injected code!\n\0".as_bytes(), rodata_region as usize)
-                    .apply()?;
-
-                let orig_regs = context.remote()?.read_regs()?;
-                println!("{:?}", orig_regs);
-                let regs = libc::user_regs_struct {
-                    rip: code_region,
-                    rsp: stack_region + 0x1000,
-                    ..orig_regs
-                };
-                context.remote()?.write_regs(regs)?;
-                println!("{:?}", context.remote()?.unpause()?);
-                println!("{:016x}", context.remote()?.read_regs()?.rip);
-                context.remote()?.write_regs(orig_regs)?;
             }
             ReplCommand::Exit(()) => unreachable!("Should be handled earlier"),
         }

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -289,10 +289,9 @@ mod example {
             ReplCommand::Inject(()) => {
                 context.load_debuginfo_if_necessary()?;
 
-                return headcrab_inject::inject_clif_code(
-                    context.remote()?,
-                    context.debuginfo().get_symbol_address("puts").unwrap() as u64,
-                );
+                return headcrab_inject::inject_clif_code(context.remote()?, &|sym| {
+                    context.debuginfo().get_symbol_address(sym).unwrap() as u64
+                });
             }
             ReplCommand::Exit(()) => unreachable!("Should be handled earlier"),
         }

--- a/headcrab_inject/Cargo.toml
+++ b/headcrab_inject/Cargo.toml
@@ -15,4 +15,6 @@ readme = "../README.md"
 headcrab = { version = "0.2.0", path = "../" }
 cranelift-codegen = "0.66.0"
 cranelift-reader = "0.66.0"
+cranelift-module = "0.66.0"
 libc = "0.2.76"
+target-lexicon = "0.10.0"

--- a/headcrab_inject/Cargo.toml
+++ b/headcrab_inject/Cargo.toml
@@ -18,3 +18,6 @@ cranelift-reader = "0.66.0"
 cranelift-module = "0.66.0"
 libc = "0.2.76"
 target-lexicon = "0.10.0"
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.17.0"

--- a/headcrab_inject/Cargo.toml
+++ b/headcrab_inject/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "headcrab_inject"
+version = "0.1.0"
+authors = ["Headcrab Contributors"]
+edition = "2018"
+description = "A code injection plugin for Headcrab."
+repository = "https://github.com/headcrab-rs/headcrab/"
+license = "MIT OR Apache-2.0"
+categories = ["development-tools::debugging"]
+documentation = "https://docs.rs/headcrab_jit"
+homepage = "https://headcrab.rs/"
+readme = "../README.md"
+
+[dependencies]
+headcrab = { version = "0.2.0", path = "../" }
+cranelift-codegen = "0.66.0"
+cranelift-reader = "0.66.0"
+libc = "0.2.76"

--- a/headcrab_inject/Cargo.toml
+++ b/headcrab_inject/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headcrab_inject"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Headcrab Contributors"]
 edition = "2018"
 description = "A code injection plugin for Headcrab."

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -163,22 +163,9 @@ pub fn compile_clif_code(
 pub fn inject_clif_code(
     remote: &LinuxTarget,
     lookup_symbol: &dyn Fn(&str) -> u64,
+    code: &str,
 ) -> Result<(), Box<dyn Error>> {
     let mut inj_ctx = InjectionContext::new(remote);
-
-    let code = r#"
-    ; data0: "Hello World from injected code!\n\0"
-    ; func0: puts
-    function u0:1() system_v {
-        gv0 = symbol colocated u1:0
-        sig0 = (i64) system_v
-        fn0 = u0:0 sig0
-
-    block0:
-        v0 = global_value.i64 gv0
-        call fn0(v0)
-        return
-    }"#;
 
     for line in code.lines() {
         let line = line.trim();

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -1,3 +1,6 @@
+// FIXME make this work on other systems too.
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+
 use std::{collections::HashMap, error::Error};
 
 use cranelift_codegen::{

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -84,6 +84,10 @@ impl<'a> InjectionContext<'a> {
         Ok(inj_ctx)
     }
 
+    pub fn target(&self) -> &LinuxTarget {
+        self.target
+    }
+
     pub fn allocate_code(&mut self, size: u64) -> Result<u64, Box<dyn Error>> {
         self.code.allocate(self.target, size, 8)
     }

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -106,7 +106,6 @@ pub fn compile_clif_code(
 ) -> Result<u64, Box<dyn Error>> {
     let functions = cranelift_reader::parse_functions(code).unwrap();
     assert!(functions.len() == 1);
-    println!("{}", functions[0]);
 
     let mut flag_builder = settings::builder();
     flag_builder.set("use_colocated_libcalls", "false").unwrap();
@@ -128,8 +127,6 @@ pub fn compile_clif_code(
         &mut binemit::NullStackmapSink {},
     )
     .unwrap();
-    println!("{}", ctx.func);
-    println!("{:?}", relocs.0);
 
     let code_region = inj_ctx.allocate_code(code_mem.len() as u64)?;
 
@@ -185,7 +182,7 @@ pub fn inject_clif_code(remote: &LinuxTarget, puts_addr: u64) -> Result<(), Box<
         r#"
     target x86_64-unknown-linux-gnu haswell
 
-    function u0:0() system_v {
+    function u0:1() system_v {
         gv0 = symbol colocated u1:0
         sig0 = (i64) system_v
         fn0 = u0:0 sig0

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -1,0 +1,163 @@
+use cranelift_codegen::{binemit, ir, isa, settings};
+use headcrab::target::{LinuxTarget, UnixTarget};
+
+#[derive(Debug)]
+struct RelocEntry {
+    offset: binemit::CodeOffset,
+    reloc: binemit::Reloc,
+    name: ir::ExternalName,
+    addend: binemit::Addend,
+}
+
+#[derive(Default)]
+struct VecRelocSink(Vec<RelocEntry>);
+
+impl binemit::RelocSink for VecRelocSink {
+    fn reloc_block(&mut self, _: binemit::CodeOffset, _: binemit::Reloc, _: binemit::CodeOffset) {
+        todo!()
+    }
+    fn reloc_external(
+        &mut self,
+        offset: binemit::CodeOffset,
+        _: ir::SourceLoc,
+        reloc: binemit::Reloc,
+        name: &ir::ExternalName,
+        addend: binemit::Addend,
+    ) {
+        self.0.push(RelocEntry {
+            offset,
+            reloc,
+            name: name.clone(),
+            addend,
+        });
+    }
+    fn reloc_constant(&mut self, _: binemit::CodeOffset, _: binemit::Reloc, _: ir::ConstantOffset) {
+        todo!()
+    }
+    fn reloc_jt(&mut self, _: binemit::CodeOffset, _: binemit::Reloc, _: ir::entities::JumpTable) {
+        todo!()
+    }
+}
+
+pub fn inject_clif_code(
+    remote: &LinuxTarget,
+    puts_addr: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let functions = cranelift_reader::parse_functions(
+        r#"
+    target x86_64-unknown-linux-gnu haswell
+
+    function u0:0() system_v {
+        gv0 = symbol colocated u1:0
+        sig0 = (i64) system_v
+        fn0 = u0:0 sig0
+
+    block0:
+        v0 = global_value.i64 gv0
+        call fn0(v0)
+        return
+    }
+    "#,
+    )
+    .unwrap();
+    assert!(functions.len() == 1);
+    println!("{}", functions[0]);
+
+    let flags_builder = settings::builder();
+    let flags = settings::Flags::new(flags_builder);
+    let isa = isa::lookup("x86_64".parse().unwrap())
+        .unwrap()
+        .finish(flags);
+
+    let mut code_mem = Vec::new();
+    let mut relocs = VecRelocSink::default();
+
+    let mut ctx = cranelift_codegen::Context::new();
+    ctx.func = functions.into_iter().next().unwrap();
+    ctx.compile_and_emit(
+        &*isa,
+        &mut code_mem,
+        &mut relocs,
+        &mut binemit::NullTrapSink {},
+        &mut binemit::NullStackmapSink {},
+    )
+    .unwrap();
+    println!("{}", ctx.func);
+    println!("{:?}", relocs.0);
+
+    let code_region = remote.mmap(
+        0 as *mut _,
+        code_mem.len(),
+        libc::PROT_READ | libc::PROT_EXEC,
+        libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+        0,
+        0,
+    )?;
+    let rodata_region = remote.mmap(
+        0 as *mut _,
+        "Hello World from injected code!\n\0".len(),
+        libc::PROT_READ,
+        libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+        0,
+        0,
+    )?;
+    let stack_region = remote.mmap(
+        0 as *mut _,
+        0x1000,
+        libc::PROT_READ | libc::PROT_WRITE,
+        libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+        0,
+        0,
+    )?;
+    println!(
+        "code: 0x{:016x} stack: 0x{:016x}",
+        code_region, stack_region
+    );
+
+    for reloc_entry in relocs.0 {
+        let sym = match reloc_entry.name {
+            ir::ExternalName::User {
+                namespace: 0,
+                index: 0,
+            } => {
+                // puts
+                puts_addr
+            }
+            ir::ExternalName::User {
+                namespace: 1,
+                index: 0,
+            } => rodata_region,
+            _ => todo!("{:?}", reloc_entry.name),
+        };
+        match reloc_entry.reloc {
+            binemit::Reloc::Abs8 => {
+                code_mem[reloc_entry.offset as usize..reloc_entry.offset as usize + 8]
+                    .copy_from_slice(&u64::to_ne_bytes((sym as i64 + reloc_entry.addend) as u64));
+            }
+            _ => todo!("reloc kind for {:?}", reloc_entry),
+        }
+    }
+
+    remote
+        .write()
+        .write_slice(&code_mem, code_region as usize)
+        .write_slice(
+            "Hello World from injected code!\n\0".as_bytes(),
+            rodata_region as usize,
+        )
+        .apply()?;
+
+    let orig_regs = remote.read_regs()?;
+    println!("{:?}", orig_regs);
+    let regs = libc::user_regs_struct {
+        rip: code_region,
+        rsp: stack_region + 0x1000,
+        ..orig_regs
+    };
+    remote.write_regs(regs)?;
+    println!("{:?}", remote.unpause()?);
+    println!("{:016x}", remote.read_regs()?.rip);
+    remote.write_regs(orig_regs)?;
+
+    Ok(())
+}

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -214,7 +214,6 @@ pub fn inject_clif_code(
     );
 
     let orig_regs = remote.read_regs()?;
-    println!("{:?}", orig_regs);
     let regs = libc::user_regs_struct {
         rip: code_region,
         rsp: stack_region + 0x1000,

--- a/headcrab_inject/src/memory.rs
+++ b/headcrab_inject/src/memory.rs
@@ -85,7 +85,7 @@ impl Memory {
 
     pub fn new_writable() -> Self {
         Self {
-            prot: libc::PROT_READ | libc::PROT_EXEC,
+            prot: libc::PROT_READ | libc::PROT_WRITE,
             allocations: Vec::new(),
             current: PtrLen::new(),
             position: 0,

--- a/headcrab_inject/src/memory.rs
+++ b/headcrab_inject/src/memory.rs
@@ -1,0 +1,139 @@
+// Based on https://github.com/bytecodealliance/wasmtime/blob/48fab12142c971405ab1c56fdceadf78bc2bbff4/cranelift/simplejit/src/memory.rs
+
+use std::mem;
+
+use headcrab::target::LinuxTarget;
+
+/// Round `size` up to the nearest multiple of `page_size`.
+fn round_up_to_page_size(size: u64, page_size: u64) -> u64 {
+    (size + (page_size - 1)) & !(page_size - 1)
+}
+
+/// A simple struct consisting of a pointer and length.
+struct PtrLen {
+    ptr: u64,
+    len: u64,
+}
+
+impl PtrLen {
+    /// Create a new empty `PtrLen`.
+    fn new() -> Self {
+        Self { ptr: 0, len: 0 }
+    }
+
+    /// Create a new `PtrLen` pointing to at least `size` bytes of memory,
+    /// suitably sized and aligned for memory protection.
+    fn with_size(
+        target: &LinuxTarget,
+        size: u64,
+        prot: libc::c_int,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let page_size = *headcrab::target::PAGE_SIZE as u64;
+        let alloc_size = round_up_to_page_size(size, page_size);
+        let ptr = target.mmap(
+            0 as *mut _,
+            alloc_size as usize,
+            prot,
+            libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+            0,
+            0,
+        )?;
+        Ok(Self {
+            ptr,
+            len: alloc_size,
+        })
+    }
+}
+
+impl Drop for PtrLen {
+    fn drop(&mut self) {
+        if self.ptr != 0 {
+            todo!("unmap")
+        }
+    }
+}
+
+/// JIT memory manager. This manages pages of suitably aligned and
+/// accessible memory. Memory will be leaked by default to have
+/// function pointers remain valid for the remainder of the
+/// program's life.
+pub struct Memory {
+    prot: libc::c_int,
+    allocations: Vec<PtrLen>,
+    current: PtrLen,
+    position: u64,
+}
+
+impl Memory {
+    pub fn new_executable() -> Self {
+        Self {
+            prot: libc::PROT_READ | libc::PROT_EXEC,
+            allocations: Vec::new(),
+            current: PtrLen::new(),
+            position: 0,
+        }
+    }
+
+    pub fn new_readonly() -> Self {
+        Self {
+            prot: libc::PROT_READ,
+            allocations: Vec::new(),
+            current: PtrLen::new(),
+            position: 0,
+        }
+    }
+
+    pub fn new_writable() -> Self {
+        Self {
+            prot: libc::PROT_READ | libc::PROT_EXEC,
+            allocations: Vec::new(),
+            current: PtrLen::new(),
+            position: 0,
+        }
+    }
+
+    pub fn allocate(
+        &mut self,
+        target: &LinuxTarget,
+        size: u64,
+        align: u8,
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        if self.position % align as u64 != 0 {
+            self.position += align as u64 - self.position % align as u64;
+            debug_assert!(self.position % align as u64 == 0);
+        }
+
+        if size <= self.current.len - self.position {
+            // TODO: Ensure overflow is not possible.
+            let ptr = self.current.ptr + self.position;
+            self.position += size;
+            return Ok(ptr);
+        }
+
+        // Finish current
+        self.allocations
+            .push(mem::replace(&mut self.current, PtrLen::new()));
+        self.position = 0;
+
+        // TODO: Allocate more at a time.
+        self.current = PtrLen::with_size(target, size, self.prot)?;
+        self.position = size;
+        Ok(self.current.ptr)
+    }
+
+    /// Frees all allocated memory regions that would be leaked otherwise.
+    /// Likely to invalidate existing function pointers, causing unsafety.
+    pub unsafe fn free_memory(&mut self) {
+        self.allocations.clear();
+    }
+}
+
+impl Drop for Memory {
+    fn drop(&mut self) {
+        // leak memory to guarantee validity of function pointers
+        mem::take(&mut self.allocations)
+            .into_iter()
+            .for_each(mem::forget);
+        mem::forget(mem::replace(&mut self.current, PtrLen::new()));
+    }
+}

--- a/headcrab_inject/tests/inject_abort.rs
+++ b/headcrab_inject/tests/inject_abort.rs
@@ -1,0 +1,90 @@
+//! Tests we can inject code in a process calling `abort()`.
+
+mod test_utils;
+
+#[cfg(target_os = "linux")]
+use cranelift_codegen::{
+    isa,
+    settings::{self, Configurable},
+};
+#[cfg(target_os = "linux")]
+use cranelift_module::FuncId;
+#[cfg(target_os = "linux")]
+use headcrab::{symbol::RelocatedDwarf, target::UnixTarget};
+#[cfg(target_os = "linux")]
+use headcrab_inject::{compile_clif_code, InjectionContext};
+#[cfg(target_os = "linux")]
+use nix::sys::{signal::Signal, wait::WaitStatus};
+
+static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
+
+// FIXME: Running this test just for linux because of privileges issue on macOS. Enable for everything after fixing.
+#[cfg(target_os = "linux")]
+#[test]
+fn inject_abort() -> Result<(), Box<dyn std::error::Error>> {
+    test_utils::ensure_testees();
+
+    let target = test_utils::launch(BIN_PATH);
+
+    let mut debuginfo = RelocatedDwarf::from_maps(&target.memory_maps()?)?;
+
+    test_utils::patch_breakpoint(&target, &debuginfo);
+
+    target.unpause()?;
+
+    debuginfo = RelocatedDwarf::from_maps(&target.memory_maps()?)?;
+    let mut inj_ctx = InjectionContext::new(&target)?;
+    let abort_function = debuginfo.get_symbol_address("abort").unwrap() as u64;
+    println!("exit fn ptr: {:016x}", abort_function);
+    inj_ctx.define_function(FuncId::from_u32(0), abort_function);
+
+    let mut flag_builder = settings::builder();
+    flag_builder.set("use_colocated_libcalls", "false").unwrap();
+    let flags = settings::Flags::new(flag_builder);
+    let isa = isa::lookup("x86_64".parse().unwrap())
+        .unwrap()
+        .finish(flags);
+
+    let functions = cranelift_reader::parse_functions(
+        r#"
+        function u0:1() system_v {
+            sig0 = () system_v
+            fn0 = u0:0 sig0
+
+        block0:
+            call fn0()
+            return
+        }"#,
+    )
+    .unwrap();
+    let mut ctx = cranelift_codegen::Context::new();
+    for func in functions {
+        ctx.clear();
+        ctx.func = func;
+        compile_clif_code(&mut inj_ctx, &*isa, &mut ctx)?;
+    }
+
+    let run_function = inj_ctx.lookup_function(FuncId::from_u32(1));
+    let stack_region = inj_ctx.allocate_readwrite(0x1000)?;
+    println!(
+        "run function: 0x{:016x} stack: 0x{:016x}",
+        run_function, stack_region
+    );
+
+    let orig_regs = inj_ctx.target().read_regs()?;
+    println!("orig rip: {:016x}", orig_regs.rip);
+    let regs = libc::user_regs_struct {
+        rip: run_function,
+        rsp: stack_region + 0x1000,
+        ..orig_regs
+    };
+    inj_ctx.target().write_regs(regs)?;
+    let res = inj_ctx.target().unpause()?;
+    if let WaitStatus::Stopped(_, Signal::SIGABRT) = res {
+    } else {
+        println!("rip: {:016x}", inj_ctx.target().read_regs()?.rip);
+        panic!("{:?}", res);
+    }
+
+    Ok(())
+}

--- a/headcrab_inject/tests/inject_abort.rs
+++ b/headcrab_inject/tests/inject_abort.rs
@@ -3,11 +3,6 @@
 mod test_utils;
 
 #[cfg(target_os = "linux")]
-use cranelift_codegen::{
-    isa,
-    settings::{self, Configurable},
-};
-#[cfg(target_os = "linux")]
 use cranelift_module::FuncId;
 #[cfg(target_os = "linux")]
 use headcrab::{symbol::RelocatedDwarf, target::UnixTarget};
@@ -38,12 +33,7 @@ fn inject_abort() -> Result<(), Box<dyn std::error::Error>> {
     println!("exit fn ptr: {:016x}", abort_function);
     inj_ctx.define_function(FuncId::from_u32(0), abort_function);
 
-    let mut flag_builder = settings::builder();
-    flag_builder.set("use_colocated_libcalls", "false").unwrap();
-    let flags = settings::Flags::new(flag_builder);
-    let isa = isa::lookup("x86_64".parse().unwrap())
-        .unwrap()
-        .finish(flags);
+    let isa = headcrab_inject::target_isa();
 
     let functions = cranelift_reader::parse_functions(
         r#"

--- a/headcrab_inject/tests/test_utils.rs
+++ b/headcrab_inject/tests/test_utils.rs
@@ -1,0 +1,1 @@
+../../tests/test_utils.rs

--- a/headcrab_inject/tests/testees
+++ b/headcrab_inject/tests/testees
@@ -1,0 +1,1 @@
+../../tests/testees

--- a/hello_dylib.rs
+++ b/hello_dylib.rs
@@ -1,0 +1,16 @@
+#![crate_type = "cdylib"]
+#![no_std]
+
+extern "C" {
+    fn puts(_: *const u8);
+}
+
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+unsafe extern "C" fn __headcrab_command() {
+    puts("Hello World from dylib!\0" as *const str as *const u8);
+}

--- a/src/target/linux.rs
+++ b/src/target/linux.rs
@@ -23,7 +23,7 @@ pub use readmem::ReadMemory;
 pub use writemem::WriteMemory;
 
 lazy_static::lazy_static! {
-    static ref PAGE_SIZE: usize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize };
+    pub static ref PAGE_SIZE: usize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize };
     #[cfg(target_arch="x86_64")]
     static ref DEBUG_REG_OFFSET: usize = unsafe {
         let x = std::mem::zeroed::<libc::user>();


### PR DESCRIPTION
```
Starting program: tests/testees/hello
Stopped(Pid(10787), SIGTRAP)
> _patch_breakpoint_function
> cont
Stopped(Pid(10787), SIGTRAP)
> inject examples/inject_hello_world.clif
run function: 0x00007ffff7fca030 stack: 0x00007ffff7fc8ff8
Hello World from injected code!
Stopped(Pid(10787), SIGTRAP) at 0x00007ffff7fca001
> injectlib libhello_dylib.so
run function: 0x00007ffff7fc7008 stack: 0x00007ffff7fc5ff8
orig rip: 0000555555559295
Hello World from dylib!
Stopped(Pid(10787), SIGTRAP) at 0x00007ffff7fc7001
> cont
Hello, world!
 42
Exited(Pid(10787), 0)
Exit
```

I will leave the following improvements [I mentioned on zulip](https://headcrab.zulipchat.com/#narrow/stream/248039-general/topic/injecting.20code.20into.20process/near/209233083) to a followup:

* allow reusing code across multiple inject invocations
* support deallocation
* support debugging of injected code