### PR TITLE
refactor(target_arch): pass arch via feature flags instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ repl_tools = { path = "./repl_tools" }
 headcrab_inject = { path = "./headcrab_inject" }
 
 [features]
+default = ["x86_64"]
+x86_64 = []
 syntax-highlighting = ["syntect"]
 
 [workspace]

--- a/headcrab_inject/Cargo.toml
+++ b/headcrab_inject/Cargo.toml
@@ -21,3 +21,7 @@ target-lexicon = "0.10.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = "0.17.0"
+
+[features]
+default = ["x86_64"]
+x86_64 = []

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -1,5 +1,5 @@
 // FIXME make this work on other systems too.
-#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![cfg(all(feature = "x86_64", target_os = "linux"))]
 
 use std::{collections::HashMap, error::Error};
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -20,6 +20,10 @@ pub use windows::*;
 
 mod thread;
 
+pub enum Arch {
+    X86_64,
+}
+
 #[derive(Debug)]
 pub struct MemoryMap {
     /// Start and end range of the mapped memory.

--- a/tests/readregs.rs
+++ b/tests/readregs.rs
@@ -4,7 +4,7 @@ mod test_utils;
 
 static BIN_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/testees/hello");
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(target_os = "linux", feature = "x86_64"))]
 #[test]
 fn read_regs() -> Result<(), Box<dyn std::error::Error>> {
     test_utils::ensure_testees();


### PR DESCRIPTION
Related to: https://github.com/headcrab-rs/headcrab/issues/102  
It's not clear to me: should the new `Arch` enum be used anywhere now?