### PR TITLE
Use {:#016x?} for register printing

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -352,7 +352,7 @@ mod example {
                 "" => Err(format!(
                     "Expected subcommand found nothing. Try `regs read`"
                 ))?,
-                "read" => println!("{:?}", context.remote()?.read_regs()?),
+                "read" => println!("{:#016x?}", context.remote()?.read_regs()?),
                 _ => Err(format!("Unknown `regs` subcommand `{}`", sub_cmd))?,
             },
             ReplCommand::Backtrace(sub_cmd) => {


### PR DESCRIPTION
The `x` causes all numbers to be formatted as hex. The `#` causes both an `0x` prefix to be added to all hex numbers and the register struct to span multiple lines. The `016` causes all hex numbers to be zero padded to 16 chars.

Found this trick at http://dtrace.org/blogs/bmc/2020/10/11/rust-after-the-honeymoon/