### PR TITLE
Fix race condition in the writemem test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ readme = "README.md"
 [dependencies]
 lazy_static = "1.4.0"
 object = "0.20"
-gimli = "0.22.0"
+gimli = "0.26.1"
 capstone = "0.7.0"
-addr2line = "0.13.0"
+addr2line = "0.17.0"
 syntect = {version = "4.4.0", optional = true}
 
 # Dependencies specific to macOS & Linux

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -69,13 +69,7 @@ pub type Reader<'a> = gimli::EndianReader<gimli::RunTimeEndian, RcCow<'a, [u8]>>
 pub struct ParsedDwarf<'a> {
     object: object::File<'a>,
     addr2line: addr2line::Context<Reader<'a>>,
-    vars: BTreeMap<
-        String,
-        (
-            gimli::CompilationUnitHeader<Reader<'a>>,
-            gimli::Expression<Reader<'a>>,
-        ),
-    >,
+    vars: BTreeMap<String, (gimli::UnitHeader<Reader<'a>>, gimli::Expression<Reader<'a>>)>,
     symbols: Vec<Symbol<'a>>,
     symbol_names: HashMap<String, usize>,
 }
@@ -110,11 +104,9 @@ impl<'a> ParsedDwarf<'a> {
                 None => Ok(gimli::EndianReader::new(RcCow::Borrowed(&[][..]), endian)),
             }
         };
-        // we don't support supplementary object files for now
-        let sup_loader = |_| Ok(gimli::EndianReader::new(RcCow::Borrowed(&[][..]), endian));
 
         // Create `EndianSlice`s for all of the sections.
-        let dwarf = gimli::Dwarf::load(loader, sup_loader)?;
+        let dwarf = gimli::Dwarf::load(loader)?;
 
         let addr2line = addr2line::Context::from_dwarf(dwarf)?;
         let dwarf = addr2line.dwarf();

--- a/src/target/linux/software_breakpoint.rs
+++ b/src/target/linux/software_breakpoint.rs
@@ -25,7 +25,7 @@ impl Breakpoint {
     pub(crate) fn new(addr: usize, pid: Pid) -> Result<Self, BreakpointError> {
         let mut shadow = 0_i64;
         unsafe {
-            ReadMemory::new(&LinuxTarget::new(pid))
+            ReadMemory::new(&LinuxTarget::from_debuggee_pid(pid))
                 .read(&mut shadow, addr)
                 .apply()
         }


### PR DESCRIPTION
- Update `gimli` and `addr2line` deps.
- Fix race in the `writemem` test: it incorrectly called both `PTRACE_TRACEME` in the child process and `PTRACE_ATTACH` in the parent process while only `PTRACE_TRACEME` is required. This could have resulted in a race condition.
- Expose `LinuxTarget::new` as public API for the cases when we know that the tracee expects to be attached to (i.e. it called `PTRACE_TRACEME`).