### PR TITLE
Update Cranelift dependency in headcrab_inject

### DIFF
--- a/headcrab_inject/Cargo.toml
+++ b/headcrab_inject/Cargo.toml
@@ -13,9 +13,9 @@ readme = "../README.md"
 
 [dependencies]
 headcrab = { version = "0.2.0", path = "../" }
-cranelift-codegen = "0.66.0"
-cranelift-reader = "0.66.0"
-cranelift-module = "0.66.0"
+cranelift-codegen = "0.82.3"
+cranelift-reader = "0.82.3"
+cranelift-module = "0.82.3"
 libc = "0.2.76"
 target-lexicon = "0.10.0"
 

--- a/headcrab_inject/src/lib.rs
+++ b/headcrab_inject/src/lib.rs
@@ -26,9 +26,12 @@ pub fn target_isa() -> Box<dyn TargetIsa> {
     let mut flag_builder = settings::builder();
     flag_builder.set("use_colocated_libcalls", "false").unwrap();
     let flags = settings::Flags::new(flag_builder);
+
+    // TODO: better error handling
     isa::lookup("x86_64".parse().unwrap())
         .unwrap()
         .finish(flags)
+        .unwrap()
 }
 
 fn parse_func_or_data(s: &str) -> FuncOrDataId {
@@ -108,7 +111,8 @@ pub fn inject_clif_code(
     let flags = settings::Flags::new(flag_builder);
     let isa = isa::lookup("x86_64".parse().unwrap())
         .unwrap()
-        .finish(flags);
+        .finish(flags)
+        .unwrap();
 
     let functions = cranelift_reader::parse_functions(code).unwrap();
     let mut ctx = cranelift_codegen::Context::new();


### PR DESCRIPTION
* Fix the `inject_abort` test.
* Simplify injection code (we don't need to use sinks to obtain relocs info anymore).